### PR TITLE
feat: complete V2 screenplay and linked editing frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ apps/*/.env.*
 !apps/*/.env.example
 
 # Local caches and generated indexes
+.codex/
+.superpowers/
 .codegraph/
 apps/*/.codegraph/
 .pytest_cache/

--- a/apps/web/scripts/perf/check-build-budget.mjs
+++ b/apps/web/scripts/perf/check-build-budget.mjs
@@ -7,7 +7,8 @@ const DIST_ASSETS = new URL("../../dist/assets/", import.meta.url);
 const DIST_INDEX_HTML = new URL("../../dist/index.html", import.meta.url);
 const MAX_MAIN_JS_BYTES = 650 * 1024;
 const MAX_INITIAL_JS_BYTES = 475 * 1024;
-const MAX_TOTAL_JS_BYTES = 1250 * 1024;
+const MAX_TOTAL_JS_BYTES = 1280 * 1024;
+const MAX_SCREENPLAY_EDITOR_JS_BYTES = 32 * 1024;
 const MAX_CSS_BYTES = 180 * 1024;
 
 function bytes(value) {
@@ -51,6 +52,7 @@ const indexHtml = readIndexHtml();
 const jsAssets = assets.filter((asset) => asset.name.endsWith(".js"));
 const cssAssets = assets.filter((asset) => asset.name.endsWith(".css"));
 const mainJs = jsAssets.find((asset) => asset.name.startsWith("index-"));
+const screenplayEditorJs = jsAssets.find((asset) => asset.name.startsWith("screenplay-editor-"));
 const initialNames = initialJsNames(indexHtml);
 const initialJs = jsAssets.filter((asset) => initialNames.has(asset.name));
 const initialJsBytes = initialJs.reduce((sum, asset) => sum + asset.size, 0);
@@ -76,6 +78,11 @@ for (const asset of initialJs) {
 }
 if (totalJs > MAX_TOTAL_JS_BYTES) {
   failures.push(`total JS is ${bytes(totalJs)}, expected <= ${bytes(MAX_TOTAL_JS_BYTES)}`);
+}
+if (!screenplayEditorJs) {
+  failures.push("screenplay editor lazy chunk is missing");
+} else if (screenplayEditorJs.size > MAX_SCREENPLAY_EDITOR_JS_BYTES) {
+  failures.push(`screenplay editor JS ${screenplayEditorJs.name} is ${bytes(screenplayEditorJs.size)}, expected <= ${bytes(MAX_SCREENPLAY_EDITOR_JS_BYTES)}`);
 }
 if (totalCss > MAX_CSS_BYTES) {
   failures.push(`total CSS is ${bytes(totalCss)}, expected <= ${bytes(MAX_CSS_BYTES)}`);

--- a/apps/web/src/api/v2Client.ts
+++ b/apps/web/src/api/v2Client.ts
@@ -24,6 +24,12 @@ import type {
   V2RegisterReferenceResponse,
   V2ReferenceAttachRequest,
   V2ReferenceMutationResponse,
+  V2ScriptConfirmRequest,
+  V2ScriptConfirmResponse,
+  V2ScriptReadResponse,
+  V2ScriptSelectVersionRequest,
+  V2ScriptSelectVersionResponse,
+  V2ScriptVersionListResponse,
   V2SelectSlotVersionRequest,
   V2SlotPromptUpdateRequest,
   V2SlotReferenceUploadResponse,
@@ -51,6 +57,10 @@ import {
   normalizeWorkflowV2ReferenceMutationResponse,
   normalizeWorkflowV2RunResponse,
   normalizeV2RegisterReferenceResponse,
+  normalizeV2ScriptConfirmResponse,
+  normalizeV2ScriptReadResponse,
+  normalizeV2ScriptSelectVersionResponse,
+  normalizeV2ScriptVersionListResponse,
   normalizeV2SlotReferenceUploadResponse,
   normalizeV2InputAssetUploadResponse,
   normalizeWorkflowAssetListResponseV2,
@@ -59,31 +69,103 @@ import {
 
 const API_V2_BASE = "/api/v2";
 
+export class V2ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly details: Record<string, unknown>;
+  readonly stage?: string;
+  readonly violations: unknown[];
+  readonly suggestedActions: Array<Record<string, unknown>>;
+  readonly payload: unknown;
+
+  constructor({
+    status,
+    code,
+    message,
+    details,
+    stage,
+    violations,
+    suggestedActions,
+    payload,
+  }: {
+    status: number;
+    code?: string;
+    message: string;
+    details: Record<string, unknown>;
+    stage?: string;
+    violations: unknown[];
+    suggestedActions: Array<Record<string, unknown>>;
+    payload: unknown;
+  }) {
+    super(message);
+    this.name = "V2ApiError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+    this.stage = stage;
+    this.violations = violations;
+    this.suggestedActions = suggestedActions;
+    this.payload = payload;
+  }
+}
+
+export class V2NetworkError extends Error {
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : "Network request failed");
+    this.name = "V2NetworkError";
+    this.cause = cause;
+  }
+}
+
+export function isV2ApiError(value: unknown): value is V2ApiError {
+  return value instanceof V2ApiError;
+}
+
+export function isNetworkError(value: unknown): value is V2NetworkError {
+  return value instanceof V2NetworkError;
+}
+
 async function requestV2<T>(path: string, options: RequestInit = {}, normalize?: (value: unknown) => T): Promise<T> {
   const bodyIsFormData = typeof FormData !== "undefined" && options.body instanceof FormData;
-  const response = await fetch(`${API_V2_BASE}${path}`, {
-    headers: options.body && !bodyIsFormData ? { "Content-Type": "application/json", ...(options.headers ?? {}) } : options.headers,
-    ...options,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${API_V2_BASE}${path}`, {
+      headers: options.body && !bodyIsFormData ? { "Content-Type": "application/json", ...(options.headers ?? {}) } : options.headers,
+      ...options,
+    });
+  } catch (error) {
+    throw new V2NetworkError(error);
+  }
   const payload = response.status === 204 ? null : await response.json().catch(() => null);
   if (!response.ok) {
     const detail = payload && typeof payload === "object" && "detail" in payload ? (payload as { detail?: unknown }).detail : payload;
-    const detailRecord = detail && typeof detail === "object" && !Array.isArray(detail) ? (detail as Record<string, unknown>) : null;
+    const detailRecord = asRecord(detail);
     const code = typeof detailRecord?.code === "string" ? detailRecord.code : undefined;
     const message = detailRecord && "message" in detailRecord
       ? String(detailRecord.message)
       : typeof detail === "string"
         ? detail
         : `Request failed with status ${response.status}`;
-    const error = new Error(code ? `${code}: ${message}` : message) as Error & {
-      code?: string;
-      payload?: unknown;
-      status?: number;
-    };
-    error.code = code;
-    error.payload = payload;
-    error.status = response.status;
-    throw error;
+    const details = asRecord(detailRecord?.details) ?? {};
+    const violations = Array.isArray(detailRecord?.violations)
+      ? detailRecord.violations
+      : Array.isArray(details.violations)
+        ? details.violations
+        : [];
+    const suggestedActions = recordsFrom(detailRecord?.suggested_actions ?? details.suggested_actions);
+    const stage = firstString(detailRecord?.stage, details.stage);
+    throw new V2ApiError({
+      status: response.status,
+      code,
+      message,
+      details,
+      stage,
+      violations,
+      suggestedActions,
+      payload,
+    });
   }
   return normalize ? normalize(payload) : (payload as T);
 }
@@ -107,6 +189,34 @@ export const v2Api = {
 
   runtime(workflowId: string): Promise<WorkflowRuntimeV2> {
     return requestV2(`/workflows/${encodeURIComponent(workflowId)}/runtime`, {}, normalizeWorkflowRuntimeV2);
+  },
+
+  script(workflowId: string): Promise<V2ScriptReadResponse> {
+    return requestV2(`/workflows/${encodeURIComponent(workflowId)}/script`, {}, normalizeV2ScriptReadResponse);
+  },
+
+  confirmScript(workflowId: string, request: V2ScriptConfirmRequest): Promise<V2ScriptConfirmResponse> {
+    return requestV2(
+      `/workflows/${encodeURIComponent(workflowId)}/script/confirm`,
+      { method: "POST", body: JSON.stringify(request) },
+      normalizeV2ScriptConfirmResponse,
+    );
+  },
+
+  scriptVersions(workflowId: string): Promise<V2ScriptVersionListResponse> {
+    return requestV2(`/workflows/${encodeURIComponent(workflowId)}/script/versions`, {}, normalizeV2ScriptVersionListResponse);
+  },
+
+  selectScriptVersion(
+    workflowId: string,
+    versionId: string,
+    request: V2ScriptSelectVersionRequest,
+  ): Promise<V2ScriptSelectVersionResponse> {
+    return requestV2(
+      `/workflows/${encodeURIComponent(workflowId)}/script/versions/${encodeURIComponent(versionId)}/select`,
+      { method: "POST", body: JSON.stringify(request) },
+      normalizeV2ScriptSelectVersionResponse,
+    );
   },
 
   async events(workflowId: string, afterSeq = 0): Promise<{ events: WorkflowRuntimeEventV2[]; next_after_seq: number }> {
@@ -372,7 +482,25 @@ function normalizeWorkflowV2PlanFromChatResponse(value: unknown): V2PlanFromChat
   return {
     front_desk: (record.front_desk ?? {}) as V2PlanFromChatResponse["front_desk"],
     workflow: record.workflow ? normalizeWorkflowV2(record.workflow) : null,
+    normalized_v2_request: asRecord(record.normalized_v2_request),
+    status: typeof record.status === "string" ? record.status : null,
+    error_code: typeof record.error_code === "string" ? record.error_code : null,
+    message: typeof record.message === "string" ? record.message : null,
+    details: asRecord(record.details) ?? {},
+    suggested_actions: recordsFrom(record.suggested_actions),
   };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function recordsFrom(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => Boolean(asRecord(item))) : [];
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string");
 }
 
 function normalizeWorkflowV2ChatTargetResponse(value: unknown): V2ChatTargetResponse {

--- a/apps/web/src/api/v2Normalizers.ts
+++ b/apps/web/src/api/v2Normalizers.ts
@@ -10,7 +10,20 @@ import type {
   V2AssetLocatorResponse,
   V2AssetOwnerDisplay,
   V2ChatActionResponse,
+  V2LinkedContextSummary,
   V2RegisterReferenceResponse,
+  V2ScriptCharacter,
+  V2ScriptConfirmResponse,
+  V2ScriptDialogueLine,
+  V2ScriptLocation,
+  V2ScriptPlan,
+  V2ScriptReadResponse,
+  V2ScriptScene,
+  V2ScriptSelectVersionResponse,
+  V2ScriptShot,
+  V2ScriptStructuralDiff,
+  V2ScriptVersionListResponse,
+  V2ScriptVersionSummary,
   V2Warning,
   WorkflowAssetListResponseV2,
   WorkflowAssetListRowV2,
@@ -110,6 +123,274 @@ function numberOrNull(value: unknown): number | null | undefined {
 function stringOrNull(value: unknown): string | null | undefined {
   if (value === null) return null;
   return stringValue(value) || undefined;
+}
+
+function invalidScriptPayload(): never {
+  throw new Error("invalid_v2_script_payload");
+}
+
+function requiredScriptRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptString(record: Record<string, unknown>, key: string): string {
+  const value = stringValue(record[key]).trim();
+  if (!value) invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptAspectRatio(record: Record<string, unknown>): V2ScriptPlan["aspect_ratio"] {
+  const value = requiredScriptString(record, "aspect_ratio");
+  if (!(["16:9", "9:16", "4:3", "3:4", "1:1", "21:9"] as const).includes(value as V2ScriptPlan["aspect_ratio"])) {
+    invalidScriptPayload();
+  }
+  return value as V2ScriptPlan["aspect_ratio"];
+}
+
+function requiredScriptMaterializerMode(record: Record<string, unknown>): V2ScriptPlan["materializer_mode"] {
+  const value = requiredScriptString(record, "materializer_mode");
+  if (value !== "real" && value !== "mock") invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptSourceAction(record: Record<string, unknown>): V2ScriptVersionSummary["source_action"] {
+  const value = requiredScriptString(record, "source_action");
+  if (value !== "initial_planning" && value !== "script_editor_confirm" && value !== "agent_chat_edit") invalidScriptPayload();
+  return value;
+}
+
+function nullableScriptString(value: unknown): string | null {
+  return value === null ? null : stringValue(value) || null;
+}
+
+function nullableScriptSettingType(value: unknown): "interior" | "exterior" | null {
+  return value === "interior" || value === "exterior" ? value : null;
+}
+
+function requiredScriptInteger(record: Record<string, unknown>, key: string, minimum: number): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < minimum) invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptArray(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  if (!Array.isArray(value) || value.length === 0) invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptStringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) invalidScriptPayload();
+  return value;
+}
+
+function requiredScriptBoolean(record: Record<string, unknown>, key: string): boolean {
+  if (typeof record[key] !== "boolean") invalidScriptPayload();
+  return record[key];
+}
+
+function requiredScriptFalse(record: Record<string, unknown>, key: string): false {
+  if (record[key] !== false) invalidScriptPayload();
+  return false;
+}
+
+function optionalScriptArray(value: unknown): unknown[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) invalidScriptPayload();
+  return value;
+}
+
+function scriptRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => isRecord(item)) : [];
+}
+
+function normalizeV2ScriptDialogueLine(value: unknown): V2ScriptDialogueLine {
+  const record = requiredScriptRecord(value);
+  return {
+    dialogue_id: requiredScriptString(record, "dialogue_id"),
+    character_id: requiredScriptString(record, "character_id"),
+    performance_cue: nullableScriptString(record.performance_cue),
+    text: requiredScriptString(record, "text"),
+  };
+}
+
+function normalizeV2ScriptShot(value: unknown): V2ScriptShot {
+  const record = requiredScriptRecord(value);
+  return {
+    shot_id: requiredScriptString(record, "shot_id"),
+    scene_id: requiredScriptString(record, "scene_id"),
+    shot_index: requiredScriptInteger(record, "shot_index", 1),
+    product_ids: stringArray(record.product_ids),
+    character_ids: stringArray(record.character_ids),
+    scene_ids: stringArray(record.scene_ids),
+    reference_item_ids: stringArray(record.reference_item_ids),
+    description: requiredScriptString(record, "description"),
+    dialogue: optionalScriptArray(record.dialogue).map(normalizeV2ScriptDialogueLine),
+    narration: nullableScriptString(record.narration),
+    visual_prompt: requiredScriptString(record, "visual_prompt"),
+    duration_seconds: requiredScriptInteger(record, "duration_seconds", 1),
+  };
+}
+
+function normalizeV2ScriptScene(value: unknown): V2ScriptScene {
+  const record = requiredScriptRecord(value);
+  return {
+    scene_id: requiredScriptString(record, "scene_id"),
+    title: requiredScriptString(record, "title"),
+    description: requiredScriptString(record, "description"),
+    location_id: nullableScriptString(record.location_id),
+    shot_ids: stringArray(record.shot_ids),
+    duration_seconds: requiredScriptInteger(record, "duration_seconds", 1),
+    location_type: nullableScriptString(record.location_type),
+    time_of_day: nullableScriptString(record.time_of_day),
+    setting_type: nullableScriptSettingType(record.setting_type),
+  };
+}
+
+function normalizeV2ScriptCharacter(value: unknown): V2ScriptCharacter {
+  const record = requiredScriptRecord(value);
+  return {
+    character_id: requiredScriptString(record, "character_id"),
+    display_name: requiredScriptString(record, "display_name"),
+    description: requiredScriptString(record, "description"),
+    role: requiredScriptString(record, "role"),
+    visual_notes: requiredScriptString(record, "visual_notes"),
+    gender: nullableScriptString(record.gender),
+  };
+}
+
+function normalizeV2ScriptLocation(value: unknown): V2ScriptLocation {
+  const record = requiredScriptRecord(value);
+  return {
+    location_id: requiredScriptString(record, "location_id"),
+    display_name: requiredScriptString(record, "display_name"),
+    description: requiredScriptString(record, "description"),
+    visual_notes: requiredScriptString(record, "visual_notes"),
+    location_type: nullableScriptString(record.location_type),
+    time_of_day: nullableScriptString(record.time_of_day),
+    setting_type: nullableScriptSettingType(record.setting_type),
+  };
+}
+
+export function normalizeV2ScriptPlan(value: unknown): V2ScriptPlan {
+  const record = requiredScriptRecord(value);
+  if (record.script_plan_version !== 2) invalidScriptPayload();
+  return {
+    script_plan_version: 2,
+    script_brief_id: requiredScriptString(record, "script_brief_id"),
+    script_version_id: requiredScriptString(record, "script_version_id"),
+    language: requiredScriptString(record, "language"),
+    script_title: requiredScriptString(record, "script_title"),
+    script_text: stringValue(record.script_text),
+    scenes: requiredScriptArray(record, "scenes").map(normalizeV2ScriptScene),
+    shots: requiredScriptArray(record, "shots").map(normalizeV2ScriptShot),
+    characters: scriptRecordArray(record.characters).map(normalizeV2ScriptCharacter),
+    locations: scriptRecordArray(record.locations).map(normalizeV2ScriptLocation),
+    product_beats: stringArray(record.product_beats),
+    tone: requiredScriptString(record, "tone"),
+    visual_style: requiredScriptString(record, "visual_style"),
+    duration_seconds: requiredScriptInteger(record, "duration_seconds", 1),
+    aspect_ratio: requiredScriptAspectRatio(record),
+    materializer_mode: requiredScriptMaterializerMode(record),
+    model_id: nullableScriptString(record.model_id),
+    selected_skill_ids: stringArray(record.selected_skill_ids),
+    selected_skill_paths: stringArray(record.selected_skill_paths),
+    skill_context_warnings: scriptRecordArray(record.skill_context_warnings),
+    quality_notes: stringArray(record.quality_notes),
+    materializer_version: nullableScriptString(record.materializer_version),
+    metadata: recordValue(record.metadata) ?? {},
+    warnings: scriptRecordArray(record.warnings),
+  };
+}
+
+function normalizeV2ScriptStructuralDiff(value: unknown): V2ScriptStructuralDiff {
+  const record = requiredScriptRecord(value);
+  return {
+    added_character_ids: requiredScriptStringArray(record, "added_character_ids"),
+    archived_character_ids: requiredScriptStringArray(record, "archived_character_ids"),
+    reactivated_character_ids: requiredScriptStringArray(record, "reactivated_character_ids"),
+    updated_character_ids: requiredScriptStringArray(record, "updated_character_ids"),
+    added_location_ids: requiredScriptStringArray(record, "added_location_ids"),
+    archived_location_ids: requiredScriptStringArray(record, "archived_location_ids"),
+    reactivated_location_ids: requiredScriptStringArray(record, "reactivated_location_ids"),
+    updated_location_ids: requiredScriptStringArray(record, "updated_location_ids"),
+    added_scene_ids: requiredScriptStringArray(record, "added_scene_ids"),
+    archived_scene_ids: requiredScriptStringArray(record, "archived_scene_ids"),
+    reactivated_scene_ids: requiredScriptStringArray(record, "reactivated_scene_ids"),
+    updated_scene_ids: requiredScriptStringArray(record, "updated_scene_ids"),
+    added_shot_ids: requiredScriptStringArray(record, "added_shot_ids"),
+    archived_shot_ids: requiredScriptStringArray(record, "archived_shot_ids"),
+    reactivated_shot_ids: requiredScriptStringArray(record, "reactivated_shot_ids"),
+    updated_shot_ids: requiredScriptStringArray(record, "updated_shot_ids"),
+    added_dialogue_ids: requiredScriptStringArray(record, "added_dialogue_ids"),
+    archived_dialogue_ids: requiredScriptStringArray(record, "archived_dialogue_ids"),
+    updated_dialogue_ids: requiredScriptStringArray(record, "updated_dialogue_ids"),
+    order_changed: requiredScriptBoolean(record, "order_changed"),
+  };
+}
+
+function normalizeV2LinkedContextSummary(value: unknown): V2LinkedContextSummary {
+  const record = requiredScriptRecord(value);
+  return {
+    updated_node_ids: requiredScriptStringArray(record, "updated_node_ids"),
+    updated_item_ids: requiredScriptStringArray(record, "updated_item_ids"),
+    updated_slot_ids: requiredScriptStringArray(record, "updated_slot_ids"),
+    updated_fields: requiredScriptStringArray(record, "updated_fields"),
+    selected_asset_versions_changed: requiredScriptFalse(record, "selected_asset_versions_changed"),
+    provider_execution_started: requiredScriptFalse(record, "provider_execution_started"),
+    refresh: requiredScriptStringArray(record, "refresh"),
+  };
+}
+
+export function normalizeV2ScriptReadResponse(value: unknown): V2ScriptReadResponse {
+  const record = requiredScriptRecord(value);
+  const selectedScriptVersionId = requiredScriptString(record, "selected_script_version_id");
+  const script = normalizeV2ScriptPlan(record.script);
+  if (selectedScriptVersionId !== script.script_version_id) invalidScriptPayload();
+  return {
+    workflow_id: requiredScriptString(record, "workflow_id"),
+    selected_script_version_id: selectedScriptVersionId,
+    script,
+    events_cursor: requiredScriptInteger(record, "events_cursor", 0),
+  };
+}
+
+export function normalizeV2ScriptConfirmResponse(value: unknown): V2ScriptConfirmResponse {
+  const record = requiredScriptRecord(value);
+  return {
+    ...normalizeV2ScriptReadResponse(record),
+    structural_diff: normalizeV2ScriptStructuralDiff(record.structural_diff),
+    linked_context: normalizeV2LinkedContextSummary(record.linked_context),
+  };
+}
+
+export function normalizeV2ScriptSelectVersionResponse(value: unknown): V2ScriptSelectVersionResponse {
+  return normalizeV2ScriptConfirmResponse(value);
+}
+
+function normalizeV2ScriptVersionSummary(value: unknown): V2ScriptVersionSummary {
+  const record = requiredScriptRecord(value);
+  return {
+    script_version_id: requiredScriptString(record, "script_version_id"),
+    parent_script_version_id: nullableScriptString(record.parent_script_version_id),
+    created_at: requiredScriptString(record, "created_at"),
+    source_action: requiredScriptSourceAction(record),
+    script_title: requiredScriptString(record, "script_title"),
+    content_hash: requiredScriptString(record, "content_hash"),
+    structural_diff_summary: recordValue(record.structural_diff_summary) ?? {},
+  };
+}
+
+export function normalizeV2ScriptVersionListResponse(value: unknown): V2ScriptVersionListResponse {
+  const record = requiredScriptRecord(value);
+  return {
+    workflow_id: requiredScriptString(record, "workflow_id"),
+    selected_script_version_id: requiredScriptString(record, "selected_script_version_id"),
+    versions: scriptRecordArray(record.versions).map(normalizeV2ScriptVersionSummary),
+    events_cursor: requiredScriptInteger(record, "events_cursor", 0),
+  };
 }
 
 export function isWorkflowV2(value: unknown): value is WorkflowV2 {
@@ -311,6 +592,8 @@ export function normalizeWorkflowSlotV2(value: unknown): WorkflowSlotV2 {
     required: typeof record.required === "boolean" ? record.required : true,
     status: stringValue(record.status, "empty"),
     slot_prompt: stringValue(record.slot_prompt) || undefined,
+    system_suggested_prompt: typeof record.system_suggested_prompt === "string" ? record.system_suggested_prompt : undefined,
+    user_prompt: typeof record.user_prompt === "string" ? record.user_prompt : undefined,
     negative_prompt: stringValue(record.negative_prompt) || undefined,
     media_prompt_asset_ids: stringArray(record.media_prompt_asset_ids),
     implicit_reference_ids: stringArray(record.implicit_reference_ids),

--- a/apps/web/src/components/PlanningErrorNotice.tsx
+++ b/apps/web/src/components/PlanningErrorNotice.tsx
@@ -1,0 +1,27 @@
+import type { PlanningFailureState } from "../pages/homeWorkflowPlanning";
+
+export function PlanningErrorNotice({ error, onRetry }: { error: PlanningFailureState; onRetry: () => void }) {
+  const suggestedActions = error.suggestedActions.map(userFacingText).filter((text): text is string => Boolean(text));
+  const violations = error.violations.map(userFacingText).filter((text): text is string => Boolean(text));
+
+  return (
+    <div className="inline-error" role="alert">
+      <p>{error.message}</p>
+      {error.stage ? <p>Stage: {error.stage}</p> : null}
+      {violations.length ? <ul>{violations.map((violation) => <li key={violation}>{violation}</li>)}</ul> : null}
+      {suggestedActions.length ? <ul>{suggestedActions.map((action) => <li key={action}>{action}</li>)}</ul> : null}
+      <button className="small-action" type="button" onClick={onRetry}>Retry planning</button>
+    </div>
+  );
+}
+
+function userFacingText(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  for (const key of ["label", "message", "detail", "description"]) {
+    const text = record[key];
+    if (typeof text === "string" && text.trim()) return text;
+  }
+  return null;
+}

--- a/apps/web/src/features/workflow/canvas/NodeCardPreview.tsx
+++ b/apps/web/src/features/workflow/canvas/NodeCardPreview.tsx
@@ -23,6 +23,7 @@ export function NodeCardPreview({ data, isRunning }: NodeCardPreviewProps) {
         openStoryboardItemId={data.v2OpenStoryboardItemId}
         slotDraftsById={data.v2SlotDraftsById}
         referenceAssetsBySlotId={data.v2ReferenceAssetsBySlotId}
+        onOpenScreenplay={data.onOpenScreenplay}
         onOpenSlotEditor={data.onOpenV2SlotEditor}
         onOpenStoryboardPrompt={data.onOpenV2StoryboardPrompt}
         onSelectSlotVersion={data.onSelectV2SlotVersion}

--- a/apps/web/src/features/workflow/canvas/V2RegionCardPreview.tsx
+++ b/apps/web/src/features/workflow/canvas/V2RegionCardPreview.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type CSSProperties } from "react";
 import { ImageIcon, VideoIcon } from "../../../icons";
 import type { AssetVersionV2, WorkflowItemV2, WorkflowRuntimeV2, WorkflowSlotV2 } from "../../../types-v2.ts";
+import { effectiveSlotPrompt } from "../../../types-v2.ts";
 import { isCompleteV2Asset } from "../../../workflow-v2/assets.ts";
 import { usableAssetVersionUrl } from "../../../workflow-v2/selectors.ts";
 import type { SlotMicroEditDraft } from "../v2/slots/useSlotMicroEdit.ts";
@@ -23,6 +24,7 @@ export type V2RegionCardPreviewProps = {
   openStoryboardItemId?: string | null;
   slotDraftsById?: Record<string, SlotMicroEditDraft>;
   referenceAssetsBySlotId?: Record<string, AssetVersionV2[]>;
+  onOpenScreenplay?: (trigger: HTMLElement) => void;
   onOpenSlotEditor?: (slotId: string) => void;
   onOpenStoryboardPrompt?: (itemId: string) => void;
   onSelectSlotVersion?: (slotId: string, versionId: string) => void;
@@ -43,6 +45,7 @@ export function V2RegionCardPreview({
   openStoryboardItemId = null,
   slotDraftsById = {},
   referenceAssetsBySlotId = {},
+  onOpenScreenplay,
   onOpenSlotEditor,
   onOpenStoryboardPrompt,
   onSelectSlotVersion,
@@ -65,7 +68,7 @@ export function V2RegionCardPreview({
   );
 
   if (scriptText !== null) {
-    return <V2ScriptTextCard scriptText={scriptText} />;
+    return <V2ScriptTextCard scriptText={scriptText} onOpenScreenplay={onOpenScreenplay} />;
   }
 
   if (!region.items.length) {
@@ -118,11 +121,20 @@ function scriptTextFromItems(items: WorkflowItemV2[]): string | null {
   return typeof scriptText === "string" ? scriptText : "";
 }
 
-function V2ScriptTextCard({ scriptText }: { scriptText: string }) {
+function V2ScriptTextCard({ scriptText, onOpenScreenplay }: { scriptText: string; onOpenScreenplay?: (trigger: HTMLElement) => void }) {
   return (
-    <div className="workflow-card-preview v2-script-text-card nodrag" aria-label="Script text">
+    <button
+      type="button"
+      className="workflow-card-preview v2-script-text-card nodrag"
+      aria-label="Open screenplay editor"
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpenScreenplay?.(event.currentTarget);
+      }}
+    >
       <pre>{scriptText}</pre>
-    </div>
+    </button>
   );
 }
 
@@ -300,7 +312,6 @@ function V2StoryboardFunctionalItemCard({
                 slotView={slot}
                 onOpenSlotEditor={onOpenSlotEditor}
                 isSubmitting={slotDraftsById[slot.slot.slot_id]?.isSubmitting}
-                interactive
               />
             ))
           ) : (
@@ -330,7 +341,7 @@ function V2RegionSlotEditor({
   const slotId = slotView.slot.slot_id;
   return (
     <div className={`v2-region-slot-editor ${isOpen ? "is-open" : ""}`} data-slot-editor-id={slotId}>
-      <V2RegionSlotPreview slotView={slotView} onOpenSlotEditor={onOpenSlotEditor} isSubmitting={draft.isSubmitting} interactive />
+      <V2RegionSlotPreview slotView={slotView} onOpenSlotEditor={onOpenSlotEditor} isSubmitting={draft.isSubmitting} />
       {isOpen && slotView.workingAsset && slotView.hasUnselectedWorkingVersion ? (
         <div className="v2-region-working-version-actions">
           <span>Working version not used in current workflow</span>
@@ -356,12 +367,10 @@ function V2RegionSlotPreview({
   slotView,
   onOpenSlotEditor,
   isSubmitting,
-  interactive = true,
 }: {
   slotView: V2RegionFunctionalSlotView;
   onOpenSlotEditor?: (slotId: string) => void;
   isSubmitting?: boolean;
-  interactive?: boolean;
 }) {
   const { slot, previewAsset, runtimeStatus, displayRole } = slotView;
   const isActive = Boolean(isSubmitting) || runtimeStatus === "running" || runtimeStatus === "waiting";
@@ -376,19 +385,6 @@ function V2RegionSlotPreview({
       {loading}
     </>
   );
-  if (!interactive) {
-    return (
-      <div
-        className={`v2-region-slot-media ${roleClassName}`}
-        data-slot-status={runtimeStatus}
-        style={aspectRatioStyle}
-        onPointerDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
-      >
-        {content}
-      </div>
-    );
-  }
   return (
     <button
       type="button"
@@ -432,7 +428,7 @@ function SlotAssetPreview({ slot, asset }: { slot: WorkflowSlotV2; asset?: Asset
 
 function draftFromSlot(slot: WorkflowSlotV2): SlotMicroEditDraft {
   return {
-    prompt: slot.slot_prompt ?? "",
+    prompt: effectiveSlotPrompt(slot),
     negative_prompt: slot.negative_prompt ?? "",
     reference_asset_ids: [...(slot.explicit_reference_ids ?? [])],
     uploaded_asset_ids: [],
@@ -444,6 +440,10 @@ function draftFromSlot(slot: WorkflowSlotV2): SlotMicroEditDraft {
       status: "attached",
     })),
     dirty: false,
+    promptDirty: false,
+    referenceDirty: false,
+    base_prompt: effectiveSlotPrompt(slot),
+    base_negative_prompt: slot.negative_prompt ?? "",
     isSubmitting: false,
   };
 }

--- a/apps/web/src/features/workflow/canvas/WorkflowCanvasNodeModel.ts
+++ b/apps/web/src/features/workflow/canvas/WorkflowCanvasNodeModel.ts
@@ -50,6 +50,7 @@ export function areWorkflowCanvasNodePropsEqual(previous: NodeProps<CanvasNode>,
 	    previousData.v2SlotDraftsById === nextData.v2SlotDraftsById &&
 	    sameV2AssetVersionMap(previousData.v2ReferenceAssetsBySlotId, nextData.v2ReferenceAssetsBySlotId) &&
 	    sameV2LibraryReferenceOptions(previousData.v2LibraryReferenceOptions, nextData.v2LibraryReferenceOptions) &&
+	    previousData.onOpenScreenplay === nextData.onOpenScreenplay &&
 	    previousData.onOpenV2SlotEditor === nextData.onOpenV2SlotEditor &&
 	    previousData.onOpenV2StoryboardPrompt === nextData.onOpenV2StoryboardPrompt &&
 	    previousData.onChangeV2SlotPrompt === nextData.onChangeV2SlotPrompt &&

--- a/apps/web/src/features/workflow/canvas/WorkflowCanvasNodePreview.tsx
+++ b/apps/web/src/features/workflow/canvas/WorkflowCanvasNodePreview.tsx
@@ -136,6 +136,7 @@ export function NodeCardPreview({
         openSlotId={data.v2OpenSlotId}
         slotDraftsById={data.v2SlotDraftsById}
         referenceAssetsBySlotId={data.v2ReferenceAssetsBySlotId}
+        onOpenScreenplay={data.onOpenScreenplay}
         onOpenSlotEditor={data.onOpenV2SlotEditor}
         onSelectSlotVersion={data.onSelectV2SlotVersion}
         onDiscardSlotWorkingVersion={data.onDiscardV2SlotWorkingVersion}

--- a/apps/web/src/features/workflow/canvas/nodeDataEquality.ts
+++ b/apps/web/src/features/workflow/canvas/nodeDataEquality.ts
@@ -99,6 +99,8 @@ export function sameV2Slots(left: WorkflowSlotV2[] = [], right: WorkflowSlotV2[]
       slot.current_working_asset_id === other.current_working_asset_id &&
       slot.current_working_version_id === other.current_working_version_id &&
       slot.slot_prompt === other.slot_prompt &&
+      slot.system_suggested_prompt === other.system_suggested_prompt &&
+      slot.user_prompt === other.user_prompt &&
       slot.negative_prompt === other.negative_prompt &&
       slot.prompt_source === other.prompt_source &&
       slot.manual_prompt_dirty === other.manual_prompt_dirty &&

--- a/apps/web/src/features/workflow/canvas/useWorkflowDisplayNodeCallbacks.ts
+++ b/apps/web/src/features/workflow/canvas/useWorkflowDisplayNodeCallbacks.ts
@@ -10,6 +10,7 @@ type WorkflowDisplayNodeCallbacks = Pick<
   WorkflowNodeData,
   | "onOpenMedia"
   | "onSelectDynamicItem"
+  | "onOpenScreenplay"
   | "onOpenV2SlotEditor"
   | "onOpenV2StoryboardPrompt"
   | "onChangeV2SlotPrompt"
@@ -31,6 +32,7 @@ export function useWorkflowDisplayNodeCallbacks({
   setSelectedNodeId,
   setDetailsOpen,
   setMediaLightbox,
+  onOpenScreenplay: openScreenplay,
   workflowV2Items,
   setActiveV2StoryboardItemId,
   openV2SlotEditor,
@@ -52,6 +54,7 @@ export function useWorkflowDisplayNodeCallbacks({
   setSelectedNodeId: (nodeId: string) => void;
   setDetailsOpen: (open: boolean) => void;
   setMediaLightbox: (asset: MediaLightboxState | null) => void;
+  onOpenScreenplay: NonNullable<WorkflowDisplayNodeCallbacks["onOpenScreenplay"]>;
   workflowV2Items?: WorkflowItemV2[];
   setActiveV2StoryboardItemId: (itemId: string | null) => void;
   openV2SlotEditor: NonNullable<WorkflowDisplayNodeCallbacks["onOpenV2SlotEditor"]>;
@@ -126,6 +129,7 @@ export function useWorkflowDisplayNodeCallbacks({
     () => ({
       onOpenMedia: openMediaLightbox,
       onSelectDynamicItem: selectCanvasDynamicItem,
+      onOpenScreenplay: openScreenplay,
       onOpenV2SlotEditor: openV2SlotEditorFromCanvas,
       onOpenV2StoryboardPrompt: openV2StoryboardPrompt,
       onChangeV2SlotPrompt: changeV2SlotPrompt,
@@ -150,6 +154,7 @@ export function useWorkflowDisplayNodeCallbacks({
       discardV2WorkingVersion,
       loadV2SlotVersions,
       openMediaLightbox,
+      openScreenplay,
       openV2SlotAssetLibraryReplace,
       openV2SlotAssetLibrarySave,
       openV2SlotEditorFromCanvas,

--- a/apps/web/src/features/workflow/canvas/useWorkflowDisplayNodes.ts
+++ b/apps/web/src/features/workflow/canvas/useWorkflowDisplayNodes.ts
@@ -15,6 +15,7 @@ type WorkflowDisplayNodeCallbacks = Pick<
   WorkflowNodeData,
   | "onOpenMedia"
   | "onSelectDynamicItem"
+  | "onOpenScreenplay"
   | "onOpenV2SlotEditor"
   | "onOpenV2StoryboardPrompt"
   | "onChangeV2SlotPrompt"

--- a/apps/web/src/features/workflow/graph/useWorkflowGraphMutationController.ts
+++ b/apps/web/src/features/workflow/graph/useWorkflowGraphMutationController.ts
@@ -77,7 +77,6 @@ import {
 } from "../runtime/resolvedInputsViewModel.ts";
 import { promptFromNodePatch } from "../v2/v2PromptModel.ts";
 import { v2RegionItemsForNode } from "../v2/v2RegionNode.ts";
-import { workflowV2ToWorkflowGraph } from "../../../workflow-v2/pageAdapter.ts";
 import { splitAssetLibraryTags } from "../assets/assetLibraryReferenceModel.ts";
 import type { SaveCanvasOptions, WorkflowGraphMutationControllerArgs } from "./workflowGraphMutationControllerTypes.ts";
 
@@ -266,7 +265,7 @@ export function useWorkflowGraphMutationController(args: WorkflowGraphMutationCo
         try {
           const nextWorkflow = await v2Api.updateItemPrompt(current.workflow.workflow_id, item.item_id, { item_prompt: prompt });
           if (!shouldApplyWorkflowScopedResult(current.workflow.workflow_id, current.activeWorkflowIdRef.current)) return;
-          current.setWorkflow(workflowV2ToWorkflowGraph(nextWorkflow));
+          await current.refreshV2WorkflowGraph(nextWorkflow.workflow_id);
           current.setStatus(`${item.display_name || current.selectedPlanNode.title} prompt saved`);
         } catch (error) {
           current.setStatus(error instanceof Error ? error.message : "V2 item prompt update failed");

--- a/apps/web/src/features/workflow/graph/useWorkflowGraphSyncController.ts
+++ b/apps/web/src/features/workflow/graph/useWorkflowGraphSyncController.ts
@@ -68,6 +68,8 @@ import {
   isSuccessfulNodeStatus,
   mergeOutputPreservingQuality,
 } from "../quality/qualityReviewViewModel";
+import { createV2WorkflowHydrationRequestGuard } from "./v2WorkflowHydrationRequestGuard.ts";
+import { createV2WorkflowApplicationRevisionGuard } from "./v2WorkflowApplicationRevisionGuard.ts";
 
 type StateSetter<T> = Dispatch<SetStateAction<T>>;
 
@@ -106,10 +108,29 @@ export type WorkflowGraphSyncControllerArgs = {
 
 export function useWorkflowGraphSyncController(args: WorkflowGraphSyncControllerArgs) {
   const argsRef = useRef(args);
+  const hydrationRequestGuardRef = useRef<ReturnType<typeof createV2WorkflowHydrationRequestGuard> | null>(null);
+  if (!hydrationRequestGuardRef.current) {
+    hydrationRequestGuardRef.current = createV2WorkflowHydrationRequestGuard();
+  }
+  const hydrationRequestGuard = hydrationRequestGuardRef.current;
+  const workflowApplicationRevisionGuardRef = useRef<ReturnType<typeof createV2WorkflowApplicationRevisionGuard> | null>(null);
+  if (!workflowApplicationRevisionGuardRef.current) {
+    workflowApplicationRevisionGuardRef.current = createV2WorkflowApplicationRevisionGuard();
+  }
+  const workflowApplicationRevisionGuard = workflowApplicationRevisionGuardRef.current;
 
   useEffect(() => {
     argsRef.current = args;
   }, [args]);
+
+  useEffect(() => {
+    hydrationRequestGuard.activateWorkflow(args.workflow?.workflow_id ?? null);
+    workflowApplicationRevisionGuard.activateWorkflow(args.workflow?.workflow_id ?? null);
+    return () => {
+      hydrationRequestGuard.invalidate();
+      workflowApplicationRevisionGuard.invalidate();
+    };
+  }, [args.workflow?.workflow_id, hydrationRequestGuard, workflowApplicationRevisionGuard]);
 
   async function applyWorkflowGraph(nextWorkflow: WorkflowGraph) {
     const current = argsRef.current;
@@ -133,9 +154,10 @@ export function useWorkflowGraphSyncController(args: WorkflowGraphSyncController
 
   async function applyWorkflowV2(
     nextWorkflow: WorkflowV2,
-    options: { refreshAssetsReason?: string | false; preserveViewport?: boolean } = {},
+    options: { refreshAssetsReason?: string | false; preserveViewport?: boolean; refreshRuntime?: boolean } = {},
   ) {
     const current = argsRef.current;
+    workflowApplicationRevisionGuard.appliedWorkflow(nextWorkflow.workflow_id);
     const graph = workflowV2ToWorkflowGraph(nextWorkflow);
     current.activeWorkflowIdRef.current = nextWorkflow.workflow_id;
     clearSnapshot(nextWorkflow.workflow_id);
@@ -153,30 +175,64 @@ export function useWorkflowGraphSyncController(args: WorkflowGraphSyncController
         ? selectedNodeId
         : firstVisibleWorkflowNodeId(graph.nodes),
     );
-    current.setDetailsOpen(true);
+    if (!options.preserveViewport) {
+      current.setDetailsOpen(true);
+    }
     const refreshAssetsReason = options.refreshAssetsReason ?? "apply-workflow";
     if (refreshAssetsReason) {
       await refreshV2AssetsAndRetryMissing(nextWorkflow.workflow_id, refreshAssetsReason, nextWorkflow);
     }
-    await current.syncV2RuntimeSnapshot(nextWorkflow.workflow_id);
+    if (options.refreshRuntime !== false) await current.syncV2RuntimeSnapshot(nextWorkflow.workflow_id);
     if (!options.preserveViewport) {
       window.setTimeout(() => current.reactFlow?.fitView({ padding: 0.28 }), 0);
     }
   }
 
-  async function refreshV2WorkflowGraph(id: string) {
+  async function refreshV2WorkflowGraph(
+    id: string,
+    options: { refreshRuntime?: boolean; refreshAssets?: boolean } = {},
+  ) {
+    const requestToken = hydrationRequestGuard.begin(id);
+    const applicationCapture = workflowApplicationRevisionGuard.capture(id);
     try {
       const nextWorkflow = await v2Api.workflow(id);
       const current = argsRef.current;
-      if (!shouldApplyWorkflowScopedResult(id, current.activeWorkflowIdRef.current)) return null;
+      if (
+        !hydrationRequestGuard.isCurrent(requestToken, current.activeWorkflowIdRef.current) ||
+        !workflowApplicationRevisionGuard.isCurrent(applicationCapture, current.activeWorkflowIdRef.current) ||
+        !shouldApplyWorkflowScopedResult(id, current.activeWorkflowIdRef.current)
+      ) return null;
       const graph = workflowV2ToWorkflowGraph(nextWorkflow);
-      await applyWorkflowV2(nextWorkflow, { refreshAssetsReason: false, preserveViewport: true });
+      await applyWorkflowV2(nextWorkflow, {
+        refreshAssetsReason: false,
+        preserveViewport: true,
+        refreshRuntime: options.refreshRuntime,
+      });
+      if (!hydrationRequestGuard.isCurrent(requestToken, argsRef.current.activeWorkflowIdRef.current)) return null;
       argsRef.current.setSavedAt(graph.updated_at ?? new Date().toISOString());
-      await refreshV2AssetsAndRetryMissing(id, "workflow-refresh", nextWorkflow);
+      if (options.refreshAssets !== false) {
+        await refreshV2AssetsAndRetryMissing(id, "workflow-refresh", nextWorkflow);
+      }
+      if (!hydrationRequestGuard.isCurrent(requestToken, argsRef.current.activeWorkflowIdRef.current)) return null;
       return nextWorkflow;
     } catch {
       return null;
     }
+  }
+
+  function refreshV2WorkflowStructure(id: string) {
+    return refreshV2WorkflowGraph(id, { refreshRuntime: false, refreshAssets: false });
+  }
+
+  function captureV2WorkflowApplicationRevision(workflowId: string) {
+    return workflowApplicationRevisionGuard.capture(workflowId);
+  }
+
+  function isCurrentV2WorkflowApplicationRevision(
+    capture: ReturnType<typeof captureV2WorkflowApplicationRevision>,
+    currentActiveWorkflowId: string | null,
+  ) {
+    return workflowApplicationRevisionGuard.isCurrent(capture, currentActiveWorkflowId);
   }
 
   async function refreshV2AssetsAndRetryMissing(
@@ -483,7 +539,10 @@ export function useWorkflowGraphSyncController(args: WorkflowGraphSyncController
   const actionsRef = useRef<{
     applyWorkflowGraph: typeof applyWorkflowGraph;
     applyWorkflowV2: typeof applyWorkflowV2;
+    captureV2WorkflowApplicationRevision: typeof captureV2WorkflowApplicationRevision;
+    isCurrentV2WorkflowApplicationRevision: typeof isCurrentV2WorkflowApplicationRevision;
     refreshV2WorkflowGraph: typeof refreshV2WorkflowGraph;
+    refreshV2WorkflowStructure: typeof refreshV2WorkflowStructure;
     refreshV2AssetsAndRetryMissing: typeof refreshV2AssetsAndRetryMissing;
     currentWorkflowIsV2: typeof currentWorkflowIsV2;
     assertNotV2WorkflowForV1Api: typeof assertNotV2WorkflowForV1Api;
@@ -503,7 +562,10 @@ export function useWorkflowGraphSyncController(args: WorkflowGraphSyncController
     actionsRef.current = {
       applyWorkflowGraph,
       applyWorkflowV2,
+      captureV2WorkflowApplicationRevision,
+      isCurrentV2WorkflowApplicationRevision,
       refreshV2WorkflowGraph,
+      refreshV2WorkflowStructure,
       refreshV2AssetsAndRetryMissing,
       currentWorkflowIsV2,
       assertNotV2WorkflowForV1Api,

--- a/apps/web/src/features/workflow/graph/v2WorkflowApplicationRevisionGuard.ts
+++ b/apps/web/src/features/workflow/graph/v2WorkflowApplicationRevisionGuard.ts
@@ -1,0 +1,34 @@
+export type V2WorkflowApplicationCapture = {
+  workflowId: string;
+  revision: number;
+};
+
+export type V2WorkflowApplicationRevisionGuard = ReturnType<typeof createV2WorkflowApplicationRevisionGuard>;
+
+/** Tracks authoritative V2 workflow applications independently from request ordering. */
+export function createV2WorkflowApplicationRevisionGuard() {
+  let activeWorkflowId: string | null = null;
+  let revision = 0;
+
+  return {
+    activateWorkflow(workflowId: string | null) {
+      if (activeWorkflowId === workflowId) return;
+      activeWorkflowId = workflowId;
+      revision += 1;
+    },
+    invalidate() {
+      activeWorkflowId = null;
+      revision += 1;
+    },
+    appliedWorkflow(workflowId: string) {
+      activeWorkflowId = workflowId;
+      revision += 1;
+    },
+    capture(workflowId: string): V2WorkflowApplicationCapture {
+      return { workflowId, revision };
+    },
+    isCurrent(capture: V2WorkflowApplicationCapture, currentActiveWorkflowId: string | null) {
+      return capture.workflowId === currentActiveWorkflowId && capture.workflowId === activeWorkflowId && capture.revision === revision;
+    },
+  };
+}

--- a/apps/web/src/features/workflow/graph/v2WorkflowHydrationRequestGuard.ts
+++ b/apps/web/src/features/workflow/graph/v2WorkflowHydrationRequestGuard.ts
@@ -1,0 +1,30 @@
+export type V2WorkflowHydrationRequestToken = {
+  workflowId: string;
+  generation: number;
+};
+
+export function createV2WorkflowHydrationRequestGuard() {
+  let activeWorkflowId: string | null = null;
+  let generation = 0;
+
+  return {
+    activateWorkflow(workflowId: string | null) {
+      if (activeWorkflowId === workflowId) return;
+      activeWorkflowId = workflowId;
+      generation += 1;
+    },
+    begin(workflowId: string): V2WorkflowHydrationRequestToken {
+      if (activeWorkflowId !== workflowId) {
+        return { workflowId, generation: -1 };
+      }
+      generation += 1;
+      return { workflowId, generation };
+    },
+    isCurrent(token: V2WorkflowHydrationRequestToken, workflowId: string | null) {
+      return activeWorkflowId === workflowId && token.workflowId === workflowId && token.generation === generation;
+    },
+    invalidate() {
+      generation += 1;
+    },
+  };
+}

--- a/apps/web/src/features/workflow/page/LazyV2ScreenplayDrawer.tsx
+++ b/apps/web/src/features/workflow/page/LazyV2ScreenplayDrawer.tsx
@@ -1,0 +1,32 @@
+import { lazy, Suspense, type MutableRefObject } from "react";
+import { createPortal } from "react-dom";
+import type { ScreenplayProductOption } from "../v2/screenplay/screenplayUiHelpers.ts";
+import type { V2ScreenplayController } from "../v2/screenplay/useV2ScreenplayController.ts";
+
+const V2ScreenplayDrawer = lazy(() => import("../v2/screenplay/V2ScreenplayDrawer.tsx")
+  .then((module) => ({ default: module.V2ScreenplayDrawer })));
+
+export function LazyV2ScreenplayDrawer({
+  controller,
+  productOptions,
+  returnFocusRef,
+}: {
+  controller: V2ScreenplayController;
+  productOptions: ScreenplayProductOption[];
+  returnFocusRef: MutableRefObject<HTMLElement | null>;
+}) {
+  return createPortal(
+    <Suspense fallback={<ScreenplayDrawerLoading />}>
+      <V2ScreenplayDrawer controller={controller} productOptions={productOptions} returnFocusRef={returnFocusRef} />
+    </Suspense>,
+    document.body,
+  );
+}
+
+function ScreenplayDrawerLoading() {
+  return <div className="v2-screenplay-drawer-backdrop">
+    <aside className="v2-screenplay-drawer" role="status" aria-live="polite">
+      <p className="v2-screenplay-status">Loading screenplay editor...</p>
+    </aside>
+  </div>;
+}

--- a/apps/web/src/features/workflow/page/useWorkflowPageAssetActionControllers.ts
+++ b/apps/web/src/features/workflow/page/useWorkflowPageAssetActionControllers.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { buildVideoTimeline } from "../final-composition/finalCompositionTimelineModel.ts";
 import { useV2SlotOperations } from "../v2/slots/useV2SlotOperations.ts";
 import { useLocalRevisionOperations } from "../assets/useLocalRevisionOperations.ts";
@@ -7,6 +7,7 @@ import { useDynamicMediaOperations } from "../assets/useDynamicMediaOperations.t
 import { canShowLocalRevisionActions } from "./workflowPageNodeGuards.ts";
 import { getWorkflowNodeType } from "../canvas/workflowNodeModel.ts";
 import { useWorkflowV2DerivedState } from "../v2/useWorkflowV2DerivedState.ts";
+import { deriveV2SlotRebaseSnapshot } from "../v2/slots/v2SlotRebaseSnapshot.ts";
 
 // Adapter value bag used while the page model is being decomposed into stable controllers.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,6 +43,15 @@ export function useWorkflowPageAssetActionControllers(args: WorkflowPageAssetAct
     selectedFreeGenerationMediaType,
     selectedFreeAbsorbTargetNodes,
   } = v2DerivedState;
+  const rebaseV2SlotDrafts = args.v2SlotMicroEdit.rebaseSlots;
+  const slotRebaseSnapshot = useMemo(
+    () => deriveV2SlotRebaseSnapshot(args.workflowV2Model.workflowV2 ?? args.workflowV2Model.workflow, allV2Slots),
+    [allV2Slots, args.workflowV2Model.workflow, args.workflowV2Model.workflowV2],
+  );
+
+  useEffect(() => {
+    rebaseV2SlotDrafts(slotRebaseSnapshot.slots, slotRebaseSnapshot);
+  }, [rebaseV2SlotDrafts, slotRebaseSnapshot]);
 
   const v2SlotOperations = useV2SlotOperations({
     workflowId: args.workflow?.workflow_id,
@@ -65,6 +75,8 @@ export function useWorkflowPageAssetActionControllers(args: WorkflowPageAssetAct
     setDynamicItemPromptDrafts: args.setDynamicItemPromptDrafts,
     setV2SlotVersionsById: args.setV2SlotVersionsById,
     applyWorkflowV2: args.applyWorkflowV2,
+    captureV2WorkflowApplicationRevision: args.captureV2WorkflowApplicationRevision,
+    isCurrentV2WorkflowApplicationRevision: args.isCurrentV2WorkflowApplicationRevision,
     refreshV2WorkflowGraph: args.refreshV2WorkflowGraph,
     syncV2Snapshot: (requestWorkflowId: string) => args.v2Runtime.syncSnapshot(requestWorkflowId),
     refreshV2AssetsAndRetryMissing: args.refreshV2AssetsAndRetryMissing,

--- a/apps/web/src/features/workflow/page/useWorkflowPageLifecycle.ts
+++ b/apps/web/src/features/workflow/page/useWorkflowPageLifecycle.ts
@@ -72,6 +72,7 @@ export function useWorkflowPageLifecycle({
   setSelectedNodeRun: Dispatch<SetStateAction<NodeRunResult | null>>;
 }) {
   const flowNodesRef = useRef(flowNodes);
+  const hydratedWorkflowIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     flowNodesRef.current = flowNodes;
@@ -79,6 +80,7 @@ export function useWorkflowPageLifecycle({
 
   useEffect(() => {
     if (isRestoringWorkspace) {
+      hydratedWorkflowIdRef.current = null;
       setCanvasNodes([]);
       setFlowNodes([]);
       setFlowEdges([]);
@@ -87,15 +89,23 @@ export function useWorkflowPageLifecycle({
       return;
     }
     const baseNodes = workflow?.nodes?.length ? workflow.nodes : demoNodes;
+    const isSameV2WorkflowRefresh = Boolean(
+      workflow?.workflow_id &&
+      hydratedWorkflowIdRef.current === workflow.workflow_id &&
+      (isV2WorkflowId(workflow.workflow_id) || currentWorkflowIsV2()),
+    );
     const currentFlowNodes = currentFlowNodesForWorkflow(baseNodes, flowNodesRef.current);
     const baseFlowNodes = mapWorkflowNodes(baseNodes, nodeRunByType, currentFlowNodes);
     const baseEdges = workflow?.edges?.length ? mapWorkflowEdges(workflow.edges, baseFlowNodes) : mapWorkflowEdges(demoEdges, baseFlowNodes);
-    const baseLayoutNodes = layoutNodes(baseFlowNodes, baseEdges, {
-      preservePositionNodeIds: positionedNodeIds(baseNodes, currentFlowNodes),
-    });
+    const baseLayoutNodes = isSameV2WorkflowRefresh
+      ? baseFlowNodes
+      : layoutNodes(baseFlowNodes, baseEdges, {
+          preservePositionNodeIds: positionedNodeIds(baseNodes, currentFlowNodes),
+        });
     const snapshot = loadSnapshot(workflowId);
+    hydratedWorkflowIdRef.current = workflow?.workflow_id ?? null;
 
-    if (snapshot?.nodes?.length && isSnapshotCompatibleWithWorkflow(snapshot, workflow)) {
+    if (!isSameV2WorkflowRefresh && snapshot?.nodes?.length && isSnapshotCompatibleWithWorkflow(snapshot, workflow)) {
       const isCurrentV2Workflow = isV2WorkflowId(workflow?.workflow_id) || currentWorkflowIsV2();
       if (isCurrentV2Workflow) {
         const restored = applyV2SnapshotLayoutOnly(
@@ -108,7 +118,7 @@ export function useWorkflowPageLifecycle({
         setFlowEdges(normalizeFlowEdges(snapshot.edges.length ? snapshot.edges : baseEdges, restored.flowNodes));
         setWorkflowVariables(workflow?.variables ?? []);
         setSavedAt(snapshot.savedAt);
-        setSelectedNodeId(firstVisibleWorkflowNodeId(restored.nodes, "prompt"));
+        setSelectedNodeId((current) => isSameV2WorkflowRefresh ? preserveSelectedNodeId(restored.nodes, current) : firstVisibleWorkflowNodeId(restored.nodes, "prompt"));
         return;
       }
       const snapshotFlowNodes = normalizeFlowNodes(snapshot.flowNodes.length ? snapshot.flowNodes : mapWorkflowNodes(snapshot.nodes, nodeRunByType, []));
@@ -117,7 +127,7 @@ export function useWorkflowPageLifecycle({
       setFlowEdges(normalizeFlowEdges(snapshot.edges, snapshotFlowNodes));
       setWorkflowVariables(workflow?.variables ?? []);
       setSavedAt(snapshot.savedAt);
-      setSelectedNodeId(firstVisibleWorkflowNodeId(snapshot.nodes, "prompt"));
+      setSelectedNodeId((current) => isSameV2WorkflowRefresh ? preserveSelectedNodeId(snapshot.nodes, current) : firstVisibleWorkflowNodeId(snapshot.nodes, "prompt"));
       return;
     }
     if (snapshot?.nodes?.length && workflow?.workflow_id) clearSnapshot(workflow.workflow_id);
@@ -126,7 +136,7 @@ export function useWorkflowPageLifecycle({
     setFlowNodes(baseLayoutNodes);
     setFlowEdges(baseEdges);
     setWorkflowVariables(workflow?.variables ?? []);
-    setSelectedNodeId(firstVisibleWorkflowNodeId(baseNodes, "prompt"));
+    setSelectedNodeId((current) => isSameV2WorkflowRefresh ? preserveSelectedNodeId(baseNodes, current) : firstVisibleWorkflowNodeId(baseNodes, "prompt"));
   }, [
     activeProjectId,
     currentWorkflowIsV2,
@@ -190,4 +200,10 @@ function positionedNodeIds(nodes: WorkflowNode[], flowNodes: CanvasNode[]) {
 
 function hasCanvasPosition(position?: CanvasPosition) {
   return Number.isFinite(position?.x) && Number.isFinite(position?.y);
+}
+
+function preserveSelectedNodeId(nodes: WorkflowNode[], selectedNodeId: string) {
+  return nodes.some((node) => node.id === selectedNodeId)
+    ? selectedNodeId
+    : firstVisibleWorkflowNodeId(nodes, "prompt");
 }

--- a/apps/web/src/features/workflow/page/useWorkflowPageModel.tsx
+++ b/apps/web/src/features/workflow/page/useWorkflowPageModel.tsx
@@ -19,6 +19,7 @@ import { useWorkflowPageLifecycle } from "./useWorkflowPageLifecycle.ts";
 import { useWorkflowPageRuntimeControllers } from "./useWorkflowPageRuntimeControllers.ts";
 import { useWorkflowPageRuntimeSummaries } from "./useWorkflowPageRuntimeSummaries.ts";
 import { useWorkflowPageSurfaceAssembly } from "./useWorkflowPageSurfaceAssembly.tsx";
+import { useWorkflowPageScreenplay } from "./useWorkflowPageScreenplay.tsx";
 import { useWorkflowPageRunGraphControllers } from "./useWorkflowPageRunGraphControllers.ts";
 import { useWorkflowPageSelectionState } from "./useWorkflowPageSelectionState.ts";
 import { useWorkflowPageAssetUiState } from "./useWorkflowPageAssetUiState.ts";
@@ -48,6 +49,7 @@ import { useWorkflowWorkbenchModel } from "../workbench/useWorkflowWorkbenchMode
 import { useFinalCompositionPageController } from "../final-composition/useFinalCompositionPageController.ts";
 import { useFinalCompositionOperations } from "../final-composition/useFinalCompositionOperations.ts";
 import { useV2WorkflowAssets } from "../v2/assets/useV2WorkflowAssets.ts";
+import { v2RegionItemsForNode } from "../v2/v2RegionNode.ts";
 import { isV2WorkflowId, useWorkflowV2Model } from "../../../workflow-v2/pageAdapter.ts";
 import { selectedAssetForSlot } from "../../../workflow-v2/selectors.ts";
 import {
@@ -443,7 +445,10 @@ export function useWorkflowPageModel() {
   const {
     applyWorkflowGraph,
     applyWorkflowV2,
+    captureV2WorkflowApplicationRevision,
+    isCurrentV2WorkflowApplicationRevision,
     refreshV2WorkflowGraph,
+    refreshV2WorkflowStructure,
     refreshV2AssetsAndRetryMissing,
     currentWorkflowIsV2,
     assertNotV2WorkflowForV1Api,
@@ -458,6 +463,13 @@ export function useWorkflowPageModel() {
     syncWorkflowAdRequest,
     applyNodeRunsToCanvas,
   } = workflowGraphSync.actions;
+  const screenplay = useWorkflowPageScreenplay({
+    activeWorkflowId: workflowV2Model.isV2 ? workflow?.workflow_id ?? null : null,
+    workflowItems: workflowV2Model.workflowV2?.items ?? canvasNodes.flatMap(v2RegionItemsForNode),
+    refreshV2WorkflowGraph,
+    refreshV2WorkflowStructure,
+    syncV2RuntimeSnapshot: async (requestWorkflowId) => v2RuntimeRef.current?.syncSnapshot(requestWorkflowId),
+  });
   const {
     selectedResolvedInputs,
     setSelectedResolvedInputs,
@@ -570,6 +582,7 @@ export function useWorkflowPageModel() {
     refreshWorkflowGraph,
     refreshMediaStatus,
     refreshV2WorkflowGraph,
+    refreshV2WorkflowStructure,
     refreshV2AssetsAndRetryMissing,
     noteAffected,
     timelineLoadStarted,
@@ -584,6 +597,7 @@ export function useWorkflowPageModel() {
     handleNodePromptUpdatedEvent,
     handleItemPromptUpdatedEvent,
     handleRevisionConversationEvent,
+    screenplayActionsRef: screenplay.actionsRef,
   });
   const { canvasRuntimeEvents, v2Runtime, workflowV2Controller, v2NodeRuntimeStatusById, v2ActiveEdgeSourceNodeIds, v2SlotRuntimeStatusById } = workflowPageRuntimeControllers;
   const {
@@ -760,6 +774,8 @@ export function useWorkflowPageModel() {
     setDynamicItemPromptDrafts,
     setV2SlotVersionsById,
     applyWorkflowV2,
+    captureV2WorkflowApplicationRevision,
+    isCurrentV2WorkflowApplicationRevision,
     refreshV2WorkflowGraph,
     v2Runtime,
     refreshV2AssetsAndRetryMissing,
@@ -1054,6 +1070,7 @@ export function useWorkflowPageModel() {
     setSelectedNodeId,
     setDetailsOpen,
     setMediaLightbox,
+    onOpenScreenplay: screenplay.openScreenplay,
     workflowV2Items: workflowV2Model.workflowV2?.items,
     setActiveV2StoryboardItemId,
     openV2SlotEditor,
@@ -1181,7 +1198,7 @@ export function useWorkflowPageModel() {
     ...dynamicItemDrafts.state, ...dynamicItemDrafts.actions,
     ...finalCompositionPage.state, ...finalCompositionPage.actions,
     ...workflowConversation.state, ...workflowConversation.actions,
-    workflow, workflowV2Model, workflowWorkbenchModel, v2Runtime,
+    workflow, workflowV2Model, workflowWorkbenchModel, v2Runtime, screenplay,
     displayNodes, displayEdges, nodeTypes, isRestoringWorkspace, workspaceRestoreError,
     selectedPlanNode, selectedRun, selectedAssets, selectedOutputAssets, selectedNodeId, selectedEdgeId,
     selectedV2Items, selectedV2SlotsByItemId, selectedV2AssetVersions, selectedV2ReferenceAssets,

--- a/apps/web/src/features/workflow/page/useWorkflowPageRuntimeControllers.ts
+++ b/apps/web/src/features/workflow/page/useWorkflowPageRuntimeControllers.ts
@@ -126,6 +126,7 @@ export function useWorkflowPageRuntimeControllers(args: WorkflowPageRuntimeContr
     onEvents: async (eventWorkflowId, events) => {
       if (!shouldApplyWorkflowScopedResult(eventWorkflowId, args.activeWorkflowIdRef.current)) return;
       canvasRuntimeEvents.actions.applyV2RuntimeEventsToPage(events);
+      await args.screenplayActionsRef.current?.handleRuntimeEvents(events);
     },
     onSnapshot: (snapshotWorkflowId, runtime) => {
       if (!shouldApplyWorkflowScopedResult(snapshotWorkflowId, args.activeWorkflowIdRef.current)) return;

--- a/apps/web/src/features/workflow/page/useWorkflowPageScreenplay.tsx
+++ b/apps/web/src/features/workflow/page/useWorkflowPageScreenplay.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useRef, type MutableRefObject, type ReactNode } from "react";
+import type { WorkflowItemV2 } from "../../../types-v2.ts";
+import { LazyV2ScreenplayDrawer } from "./LazyV2ScreenplayDrawer.tsx";
+import {
+  useV2ScreenplayController,
+  type V2ScreenplayController,
+} from "../v2/screenplay/useV2ScreenplayController.ts";
+import { createV2SynchronizationRefreshCoordinator } from "../runtime/v2SynchronizationRefreshCoordinator.ts";
+
+type ScreenplayEventActions = Pick<
+  V2ScreenplayController,
+  "handleRuntimeEvents" | "refreshHistory" | "refreshSelected"
+>;
+
+export type WorkflowPageScreenplay = {
+  controllerRef: MutableRefObject<V2ScreenplayController | null>;
+  actionsRef: MutableRefObject<ScreenplayEventActions | null>;
+  openScreenplay: (trigger: HTMLElement) => void;
+  panel: ReactNode;
+};
+
+export function useWorkflowPageScreenplay({
+  activeWorkflowId,
+  workflowItems,
+  refreshV2WorkflowGraph,
+  refreshV2WorkflowStructure,
+  syncV2RuntimeSnapshot,
+}: {
+  activeWorkflowId: string | null;
+  workflowItems: WorkflowItemV2[];
+  refreshV2WorkflowGraph: (
+    workflowId: string,
+    options?: { refreshRuntime?: boolean; refreshAssets?: boolean },
+  ) => Promise<unknown>;
+  refreshV2WorkflowStructure: (workflowId: string) => Promise<unknown>;
+  syncV2RuntimeSnapshot: (workflowId: string) => Promise<unknown>;
+}): WorkflowPageScreenplay {
+  const triggerElementRef = useRef<HTMLElement | null>(null);
+  const synchronizationCoordinatorRef = useRef<ReturnType<typeof createV2SynchronizationRefreshCoordinator> | null>(null);
+  if (!synchronizationCoordinatorRef.current) {
+    synchronizationCoordinatorRef.current = createV2SynchronizationRefreshCoordinator();
+  }
+  const synchronizationCoordinator = synchronizationCoordinatorRef.current;
+  const controller = useV2ScreenplayController({
+    refreshWorkflow: (workflowId) => refreshV2WorkflowGraph(workflowId),
+    refreshRuntime: (workflowId) => syncV2RuntimeSnapshot(workflowId),
+    refreshSynchronizationWorkflow: async (workflowId, scopes) => {
+      const result = scopes.has("assets")
+        ? await refreshV2WorkflowGraph(workflowId, { refreshRuntime: false, refreshAssets: true })
+        : await refreshV2WorkflowStructure(workflowId);
+      if (result === null) throw new Error("V2 synchronization workflow refresh failed.");
+      return result;
+    },
+    synchronizationCoordinator,
+  });
+  const controllerRef = useRef<V2ScreenplayController | null>(null);
+  const actionsRef = useRef<ScreenplayEventActions | null>(null);
+  controllerRef.current = controller;
+  actionsRef.current = {
+    handleRuntimeEvents: controller.handleRuntimeEvents,
+    refreshHistory: controller.refreshHistory,
+    refreshSelected: controller.refreshSelected,
+  };
+
+  const productOptions = useMemo(
+    () => workflowItems
+      .filter((item) => item.item_type === "product" && item.lifecycle_state !== "archived")
+      .map((item) => ({ id: item.item_id, label: item.display_name || item.item_id })),
+    [workflowItems],
+  );
+  const { discardDraftAndClose, open } = controller;
+
+  const openScreenplay = useCallback((trigger: HTMLElement) => {
+    if (!activeWorkflowId) return;
+    triggerElementRef.current = trigger;
+    void open(activeWorkflowId);
+  }, [activeWorkflowId, open]);
+
+  useEffect(() => {
+    synchronizationCoordinator.activateWorkflow(activeWorkflowId);
+    return () => synchronizationCoordinator.clearWorkflow(activeWorkflowId);
+  }, [activeWorkflowId, synchronizationCoordinator]);
+
+  useEffect(() => {
+    if (!controller.state.workflowId || controller.state.workflowId === activeWorkflowId) return;
+    triggerElementRef.current = null;
+    discardDraftAndClose();
+  }, [activeWorkflowId, controller.state.workflowId, discardDraftAndClose]);
+
+  const panel = activeWorkflowId && controller.state.workflowId === activeWorkflowId
+    ? <LazyV2ScreenplayDrawer controller={controller} productOptions={productOptions} returnFocusRef={triggerElementRef} />
+    : null;
+
+  return { controllerRef, actionsRef, openScreenplay, panel };
+}

--- a/apps/web/src/features/workflow/page/useWorkflowPageSurfaceAssembly.tsx
+++ b/apps/web/src/features/workflow/page/useWorkflowPageSurfaceAssembly.tsx
@@ -4,6 +4,7 @@ import { LocalPromptComposer, type PromptGenerateContext } from "../../../compon
 import { WorkflowDraggablePanel, type PanelOffset } from "../../../components/WorkflowDraggablePanel.tsx";
 import { AssetsIcon, CloseIcon, SaveIcon } from "../../../icons";
 import type { WorkflowItemV2, WorkflowSlotV2 } from "../../../types-v2.ts";
+import { effectiveSlotPrompt } from "../../../types-v2.ts";
 import { AssetLibraryPicker, AssetLibrarySaveModal } from "../assets/AssetLibraryPanels.tsx";
 import { canSaveNodeToAssetLibrary } from "../assets/assetLibraryReferenceModel.ts";
 import { finalCompositionTimelineTargetAsset } from "../final-composition/useFinalCompositionOperations.ts";
@@ -633,7 +634,7 @@ export function useWorkflowPageSurfaceAssembly(args: WorkflowPageSurfaceAssembly
       },
       canvas,
       copilot: null,
-      panels: null,
+      panels: args.screenplay.panel,
       modals: null,
     },
     actions: {
@@ -647,7 +648,7 @@ export function useWorkflowPageSurfaceAssembly(args: WorkflowPageSurfaceAssembly
 
 function draftFromV2Slot(slot: WorkflowSlotV2): SlotMicroEditDraft {
   return {
-    prompt: slot.slot_prompt ?? "",
+    prompt: effectiveSlotPrompt(slot),
     negative_prompt: slot.negative_prompt ?? "",
     reference_asset_ids: [...(slot.explicit_reference_ids ?? [])],
     uploaded_asset_ids: [],
@@ -659,6 +660,10 @@ function draftFromV2Slot(slot: WorkflowSlotV2): SlotMicroEditDraft {
       status: "attached",
     })),
     dirty: false,
+    promptDirty: false,
+    referenceDirty: false,
+    base_prompt: effectiveSlotPrompt(slot),
+    base_negative_prompt: slot.negative_prompt ?? "",
     isSubmitting: false,
   };
 }

--- a/apps/web/src/features/workflow/runtime/useCanvasRuntimeEventController.ts
+++ b/apps/web/src/features/workflow/runtime/useCanvasRuntimeEventController.ts
@@ -30,6 +30,7 @@ import {
 import { localRevisionStateKey, pendingVisibleRevisionCandidates } from "../../../workflow/localRevision.ts";
 import { shouldApplyWorkflowScopedResult } from "../../../workflow/sessionGuards.ts";
 import { isV2WorkflowId } from "../../../workflow-v2/pageAdapter.ts";
+import { isV2SynchronizationEvent } from "../../../workflow-v2/runtime.ts";
 import { frontDeskConversationId } from "../copilot/agentConversationPanelModel.ts";
 import { assetLibraryRefreshDetailFromEvent, patchAssetLibraryState } from "../assets/dynamicItemAssetModel.ts";
 import { assetTypeFromSemanticType, latestLocalRevisionPromptMetadata, localRevisionTargetsMatch, revisionMatchesCanvasCandidate } from "../assets/localRevisionViewModel.ts";
@@ -651,6 +652,7 @@ export function useCanvasRuntimeEventController(args: CanvasRuntimeEventControll
   const applyV2RuntimeEventsToPage = useCallback((events: WorkflowRuntimeEventV2[]) => {
     if (!events.length) return;
     const workflowId = events.find((event) => event.workflow_id)?.workflow_id;
+    const runtimeEvents = events.filter((event) => !isV2SynchronizationEvent(event.event_type));
     const latestExecutionEvent = [...events].reverse().find((event) =>
       [
         "execution_queued",
@@ -686,12 +688,12 @@ export function useCanvasRuntimeEventController(args: CanvasRuntimeEventControll
         argsRef.current.setWorkflowRunning(true);
       }
     }
-    const shouldRefreshRuntime = events.some(v2EventShouldRefreshRuntime);
-    const shouldRefreshWorkflow = events.some((event) =>
+    const shouldRefreshRuntime = runtimeEvents.some(v2EventShouldRefreshRuntime);
+    const shouldRefreshWorkflow = runtimeEvents.some((event) =>
       V2_WORKFLOW_REFRESH_EVENT_TYPES.has(event.event_type) ||
       v2EventRefreshHints(event).some((hint) => hint === "workflow" || hint === "slot_versions"),
     );
-    const shouldRefreshAssets = events.some(v2EventShouldRefreshAssets);
+    const shouldRefreshAssets = runtimeEvents.some(v2EventShouldRefreshAssets);
     if (workflowId && (shouldRefreshRuntime || shouldRefreshWorkflow || shouldRefreshAssets)) {
       void (async () => {
         if (shouldRefreshRuntime || shouldRefreshAssets) await argsRef.current.v2Runtime.syncSnapshot(workflowId);

--- a/apps/web/src/features/workflow/runtime/useV2RuntimeController.ts
+++ b/apps/web/src/features/workflow/runtime/useV2RuntimeController.ts
@@ -11,7 +11,7 @@ import {
   type V2RuntimeStore,
 } from "../../../workflow-v2/runtime.ts";
 
-const V2_RUNTIME_EVENT_STREAM_TYPES = [
+export const V2_RUNTIME_EVENT_STREAM_TYPES = [
   "execution_queued",
   "execution_started",
   "execution_waiting",
@@ -49,18 +49,17 @@ const V2_RUNTIME_EVENT_STREAM_TYPES = [
   "prompt_updated",
   "item_prompt_updated",
   "slot_prompt_updated",
-  "slot_marked_stale",
   "reference_attached",
   "reference_removed",
   "slot_history_updated",
   "asset_history_updated",
   "workflow_updated",
   "resolved_inputs_updated",
-  "slot_outdated_hint_added",
-  "slot_outdated_hint_cleared",
-  "item_outdated_hint_added",
-  "node_outdated_hint_added",
   "storyboard_summary_refined",
+  "script_version_created",
+  "script_selected_version_updated",
+  "workflow_structure_updated",
+  "linked_context_updated",
 ] as const;
 
 export function useV2RuntimeController(options: {

--- a/apps/web/src/features/workflow/runtime/v2RuntimeEventModel.ts
+++ b/apps/web/src/features/workflow/runtime/v2RuntimeEventModel.ts
@@ -1,4 +1,25 @@
-import type { WorkflowRuntimeEventV2 } from "../../../types-v2.ts";
+import type {
+  V2LinkedContextSummary,
+  V2ScriptStructuralDiff,
+  WorkflowRuntimeEventV2,
+} from "../../../types-v2.ts";
+import { isV2SynchronizationEvent } from "../../../workflow-v2/runtime.ts";
+
+export type V2SynchronizationRefreshPlan = {
+  isSynchronizationBatch: boolean;
+  refreshScreenplayHistory: boolean;
+  refreshSelectedScreenplay: boolean;
+  refreshWorkflow: boolean;
+  refreshWorkflowStructure: boolean;
+  refreshSlotPrompts: boolean;
+  refreshReferences: boolean;
+  refreshAssets: boolean;
+  nodeIds: string[];
+  itemIds: string[];
+  slotIds: string[];
+  transactionIds: string[];
+  scriptVersionIds: string[];
+};
 
 const V2_SLOT_OPERATION_REFRESH_EVENTS = new Set([
   "slot_working_version_updated",
@@ -72,10 +93,6 @@ export const V2_WORKFLOW_REFRESH_EVENT_TYPES = new Set([
   "reference_attached",
   "reference_removed",
   "asset_owner_resolved",
-  "slot_outdated_hint_added",
-  "item_outdated_hint_added",
-  "node_outdated_hint_added",
-  "slot_outdated_hint_cleared",
   "storyboard_summary_refined",
   "chat_action_applied",
 ]);
@@ -133,17 +150,110 @@ export function v2EventRefreshHints(event: WorkflowRuntimeEventV2): string[] {
   return Array.isArray(refresh) ? refresh.filter((item): item is string => typeof item === "string") : [];
 }
 
+export function createV2SynchronizationRefreshPlan(events: WorkflowRuntimeEventV2[]): V2SynchronizationRefreshPlan {
+  const plan: V2SynchronizationRefreshPlan = {
+    isSynchronizationBatch: false,
+    refreshScreenplayHistory: false,
+    refreshSelectedScreenplay: false,
+    refreshWorkflow: false,
+    refreshWorkflowStructure: false,
+    refreshSlotPrompts: false,
+    refreshReferences: false,
+    refreshAssets: false,
+    nodeIds: [],
+    itemIds: [],
+    slotIds: [],
+    transactionIds: [],
+    scriptVersionIds: [],
+  };
+  const nodeIds = new Set<string>();
+  const itemIds = new Set<string>();
+  const slotIds = new Set<string>();
+  const transactionIds = new Set<string>();
+  const scriptVersionIds = new Set<string>();
+
+  for (const event of events) {
+    if (!isV2SynchronizationEvent(event.event_type)) continue;
+    plan.isSynchronizationBatch = true;
+    const refresh = v2EventRefreshHints(event);
+
+    if (event.event_type === "script_version_created") {
+      plan.refreshScreenplayHistory = true;
+    } else if (event.event_type === "script_selected_version_updated") {
+      plan.refreshScreenplayHistory = true;
+      plan.refreshSelectedScreenplay = true;
+      plan.refreshWorkflow = true;
+    } else if (event.event_type === "workflow_structure_updated") {
+      plan.refreshWorkflow = true;
+      plan.refreshWorkflowStructure = true;
+    } else if (event.event_type === "linked_context_updated") {
+      plan.refreshWorkflow ||= refresh.includes("workflow");
+      plan.refreshSlotPrompts ||= refresh.includes("slot_prompts");
+      plan.refreshReferences ||= refresh.includes("references");
+      plan.refreshAssets ||= refresh.includes("assets");
+      if (refresh.includes("script")) {
+        plan.refreshScreenplayHistory = true;
+        plan.refreshSelectedScreenplay = true;
+      }
+    }
+
+    addStrings(nodeIds, event.payload?.node_ids);
+    addStrings(itemIds, event.payload?.item_ids);
+    addStrings(slotIds, event.payload?.slot_ids);
+    if (event.node_id) nodeIds.add(event.node_id);
+    if (event.item_id) itemIds.add(event.item_id);
+    if (event.slot_id) slotIds.add(event.slot_id);
+    const transactionId = stringFromUnknown(event.payload?.transaction_id);
+    if (transactionId) transactionIds.add(transactionId);
+    const scriptVersionId = stringFromUnknown(event.payload?.script_version_id) || stringFromUnknown(event.version_id);
+    if (scriptVersionId) scriptVersionIds.add(scriptVersionId);
+  }
+
+  plan.nodeIds = Array.from(nodeIds);
+  plan.itemIds = Array.from(itemIds);
+  plan.slotIds = Array.from(slotIds);
+  plan.transactionIds = Array.from(transactionIds);
+  plan.scriptVersionIds = Array.from(scriptVersionIds);
+  return plan;
+}
+
+export function createV2LocalSynchronizationRefreshPlan(
+  scriptVersionId: string,
+  structuralDiff: V2ScriptStructuralDiff,
+  linkedContext: V2LinkedContextSummary,
+): V2SynchronizationRefreshPlan {
+  const refresh = new Set(linkedContext.refresh ?? []);
+  return {
+    isSynchronizationBatch: true,
+    refreshScreenplayHistory: true,
+    refreshSelectedScreenplay: true,
+    refreshWorkflow: true,
+    refreshWorkflowStructure: v2StructuralDiffChangesWorkflow(structuralDiff),
+    refreshSlotPrompts: refresh.has("slot_prompts"),
+    refreshReferences: refresh.has("references"),
+    refreshAssets: refresh.has("assets"),
+    nodeIds: uniqueStrings(linkedContext.updated_node_ids),
+    itemIds: uniqueStrings(linkedContext.updated_item_ids),
+    slotIds: uniqueStrings(linkedContext.updated_slot_ids),
+    transactionIds: [],
+    scriptVersionIds: scriptVersionId ? [scriptVersionId] : [],
+  };
+}
+
 export function v2EventShouldRefreshRuntime(event: WorkflowRuntimeEventV2) {
+  if (isV2SynchronizationEvent(event.event_type)) return false;
   return V2_RUNTIME_REFRESH_EVENT_TYPES.has(event.event_type) ||
     v2EventRefreshHints(event).some((hint) => hint === "runtime" || hint === "workflow" || hint === "slot_versions" || hint === "assets");
 }
 
 export function v2EventShouldRefreshAssets(event: WorkflowRuntimeEventV2) {
+  if (isV2SynchronizationEvent(event.event_type)) return false;
   return V2_ASSET_REFRESH_EVENT_TYPES.has(event.event_type) ||
     v2EventRefreshHints(event).some((hint) => hint === "assets" || hint === "slot_versions" || hint === "workflow");
 }
 
 export function v2EventShouldRefreshProviderTasks(event: WorkflowRuntimeEventV2) {
+  if (isV2SynchronizationEvent(event.event_type)) return false;
   return V2_PROVIDER_TASK_REFRESH_EVENT_TYPES.has(event.event_type) ||
     event.event_type.startsWith("provider_task_") ||
     Boolean(v2RuntimeEventProviderTaskId(event));
@@ -159,4 +269,25 @@ export function v2RuntimeEventProviderTaskId(event: WorkflowRuntimeEventV2) {
 
 function stringFromUnknown(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function addStrings(target: Set<string>, value: unknown) {
+  if (!Array.isArray(value)) return;
+  value.forEach((item) => {
+    const normalized = stringFromUnknown(item);
+    if (normalized) target.add(normalized);
+  });
+}
+
+function uniqueStrings(value: unknown): string[] {
+  const result = new Set<string>();
+  addStrings(result, value);
+  return Array.from(result);
+}
+
+function v2StructuralDiffChangesWorkflow(diff: V2ScriptStructuralDiff): boolean {
+  if (diff.order_changed) return true;
+  return Object.entries(diff).some(([key, value]) =>
+    /^(added|archived|reactivated)_(character|location|scene|shot)_ids$/.test(key) && Array.isArray(value) && value.length > 0,
+  );
 }

--- a/apps/web/src/features/workflow/runtime/v2SynchronizationRefreshCoordinator.ts
+++ b/apps/web/src/features/workflow/runtime/v2SynchronizationRefreshCoordinator.ts
@@ -1,0 +1,272 @@
+import type { V2ScriptVersionListResponse } from "../../../types-v2.ts";
+import type { V2SynchronizationRefreshPlan } from "./v2RuntimeEventModel.ts";
+
+export type V2SynchronizationRefreshScope =
+  | "history"
+  | "selected"
+  | "workflow"
+  | "workflowStructure"
+  | "slotPrompts"
+  | "references"
+  | "assets";
+
+export type V2SynchronizationRefreshActions = {
+  refreshHistory?: () => Promise<V2ScriptVersionListResponse | null | void> | V2ScriptVersionListResponse | null | void;
+  refreshSelectedScreenplay?: (history: V2ScriptVersionListResponse | null) => Promise<unknown> | unknown;
+  refreshWorkflow?: (scopes: ReadonlySet<V2SynchronizationRefreshScope>) => Promise<unknown> | unknown;
+};
+
+type LedgerEntry = {
+  workflowId: string;
+  generation: number;
+  aliases: Set<string>;
+  desired: Set<V2SynchronizationRefreshScope>;
+  handled: Set<V2SynchronizationRefreshScope>;
+  actions: V2SynchronizationRefreshActions;
+  history: V2ScriptVersionListResponse | null;
+  scheduled: number;
+  touchedAt: number;
+  parent: LedgerEntry | null;
+};
+
+type SerializationLane = {
+  generation: number;
+  tail: Promise<void>;
+};
+
+export type V2SynchronizationRefreshCoordinator = ReturnType<typeof createV2SynchronizationRefreshCoordinator>;
+
+export function createV2SynchronizationRefreshCoordinator(options: {
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+} = {}) {
+  const ttlMs = options.ttlMs ?? 60_000;
+  const maxEntries = options.maxEntries ?? 128;
+  const now = options.now ?? Date.now;
+  const entries = new Set<LedgerEntry>();
+  const aliases = new Map<string, LedgerEntry>();
+  let activeWorkflowId: string | null = null;
+  let generation = 0;
+  let lane: SerializationLane = { generation, tail: Promise.resolve() };
+
+  const rootEntry = (candidate: LedgerEntry): LedgerEntry => {
+    let root = candidate;
+    while (root.parent) root = root.parent;
+    let current = candidate;
+    while (current.parent && current.parent !== root) {
+      const parent = current.parent;
+      current.parent = root;
+      current = parent;
+    }
+    return root;
+  };
+
+  const removeEntry = (entry: LedgerEntry) => {
+    entries.delete(entry);
+    entry.aliases.forEach((alias) => {
+      if (aliases.get(alias) === entry) aliases.delete(alias);
+    });
+  };
+
+  const clear = () => {
+    entries.clear();
+    aliases.clear();
+  };
+
+  const prune = () => {
+    const timestamp = now();
+    Array.from(entries).forEach((entry) => {
+      if (entry.scheduled === 0 && timestamp - entry.touchedAt > ttlMs) removeEntry(entry);
+    });
+    while (entries.size > maxEntries) {
+      const oldest = Array.from(entries)
+        .filter((entry) => entry.scheduled === 0)
+        .sort((left, right) => left.touchedAt - right.touchedAt)[0];
+      if (!oldest) break;
+      removeEntry(oldest);
+    }
+  };
+
+  const stableAliases = (workflowId: string, plan: V2SynchronizationRefreshPlan) => [
+    ...plan.transactionIds.map((id) => `${workflowId}:transaction:${id}`),
+    ...plan.scriptVersionIds.map((id) => `${workflowId}:script:${id}`),
+  ];
+
+  const mergeActions = (target: V2SynchronizationRefreshActions, source: V2SynchronizationRefreshActions) => {
+    target.refreshHistory ??= source.refreshHistory;
+    target.refreshSelectedScreenplay ??= source.refreshSelectedScreenplay;
+    target.refreshWorkflow ??= source.refreshWorkflow;
+  };
+
+  const mergeEntries = (target: LedgerEntry, source: LedgerEntry) => {
+    source.aliases.forEach((alias) => target.aliases.add(alias));
+    source.desired.forEach((scope) => target.desired.add(scope));
+    source.handled.forEach((scope) => target.handled.add(scope));
+    mergeActions(target.actions, source.actions);
+    target.history ??= source.history;
+    target.scheduled += source.scheduled;
+    source.parent = target;
+    removeEntry(source);
+  };
+
+  const entryFor = (workflowId: string, plan: V2SynchronizationRefreshPlan): LedgerEntry => {
+    prune();
+    const requestedAliases = stableAliases(workflowId, plan);
+    const matchingEntries = Array.from(new Set(requestedAliases
+      .map((alias) => aliases.get(alias))
+      .filter((entry): entry is LedgerEntry => Boolean(entry))
+      .map(rootEntry)));
+    const entry = matchingEntries[0] ?? {
+      workflowId,
+      generation,
+      aliases: new Set<string>(),
+      desired: new Set<V2SynchronizationRefreshScope>(),
+      handled: new Set<V2SynchronizationRefreshScope>(),
+      actions: {},
+      history: null,
+      scheduled: 0,
+      touchedAt: now(),
+      parent: null,
+    };
+    matchingEntries.slice(1).forEach((other) => mergeEntries(entry, other));
+    requestedAliases.forEach((alias) => entry.aliases.add(alias));
+    entry.aliases.forEach((alias) => aliases.set(alias, entry));
+    entry.touchedAt = now();
+    if (requestedAliases.length) entries.add(entry);
+    prune();
+    return entry;
+  };
+
+  const addDesiredScopes = (entry: LedgerEntry, plan: V2SynchronizationRefreshPlan) => {
+    if (plan.refreshScreenplayHistory) entry.desired.add("history");
+    if (plan.refreshSelectedScreenplay) entry.desired.add("selected");
+    if (plan.refreshWorkflow) entry.desired.add("workflow");
+    if (plan.refreshWorkflowStructure) entry.desired.add("workflowStructure");
+    if (plan.refreshSlotPrompts) entry.desired.add("slotPrompts");
+    if (plan.refreshReferences) entry.desired.add("references");
+    if (plan.refreshAssets) entry.desired.add("assets");
+  };
+
+  const isActive = (entry: LedgerEntry) =>
+    entry.generation === generation && entry.workflowId === activeWorkflowId;
+
+  const executeScreenplayScope = async (candidate: LedgerEntry): Promise<boolean> => {
+    const entry = rootEntry(candidate);
+    if (!isActive(entry)) return false;
+    if (entry.desired.has("selected") && !entry.handled.has("selected") && entry.actions.refreshSelectedScreenplay) {
+      try {
+        await entry.actions.refreshSelectedScreenplay(entry.handled.has("history") ? entry.history : null);
+      } catch {
+        return false;
+      }
+      const current = rootEntry(entry);
+      if (!isActive(current)) return false;
+      current.handled.add("selected");
+      current.handled.add("history");
+      current.touchedAt = now();
+      return true;
+    }
+    if (entry.desired.has("history") && !entry.handled.has("history") && entry.actions.refreshHistory) {
+      let response: V2ScriptVersionListResponse | null | void;
+      try {
+        response = await entry.actions.refreshHistory();
+      } catch {
+        return false;
+      }
+      const current = rootEntry(entry);
+      if (!isActive(current)) return false;
+      current.history = response ?? null;
+      current.handled.add("history");
+      current.touchedAt = now();
+      return true;
+    }
+    return false;
+  };
+
+  const executeWorkflowScopes = async (candidate: LedgerEntry): Promise<boolean> => {
+    const entry = rootEntry(candidate);
+    if (!isActive(entry) || !entry.actions.refreshWorkflow) return false;
+    const scopes: V2SynchronizationRefreshScope[] = [];
+    const hydrationRequested = entry.desired.has("workflow") || entry.desired.has("workflowStructure");
+    const hydrationHandled = entry.handled.has("workflow") || entry.handled.has("workflowStructure");
+    if (hydrationRequested && !hydrationHandled) {
+      scopes.push(entry.desired.has("workflowStructure") ? "workflowStructure" : "workflow");
+    }
+    (["slotPrompts", "references", "assets"] as const).forEach((scope) => {
+      if (entry.desired.has(scope) && !entry.handled.has(scope)) scopes.push(scope);
+    });
+    if (!scopes.length) return false;
+    try {
+      await entry.actions.refreshWorkflow(new Set(scopes));
+    } catch {
+      return false;
+    }
+    const current = rootEntry(entry);
+    if (!isActive(current)) return false;
+    if (scopes.includes("workflow") || scopes.includes("workflowStructure")) {
+      current.handled.add("workflow");
+      current.handled.add("workflowStructure");
+    }
+    scopes.forEach((scope) => current.handled.add(scope));
+    current.touchedAt = now();
+    return true;
+  };
+
+  const drainEntry = async (candidate: LedgerEntry) => {
+    while (isActive(rootEntry(candidate))) {
+      if (await executeScreenplayScope(candidate)) continue;
+      if (await executeWorkflowScopes(candidate)) continue;
+      break;
+    }
+  };
+
+  const coordinate = async (
+    workflowId: string,
+    plan: V2SynchronizationRefreshPlan,
+    actions: V2SynchronizationRefreshActions,
+  ) => {
+    if (!plan.isSynchronizationBatch || activeWorkflowId !== workflowId) return;
+    const entry = entryFor(workflowId, plan);
+    addDesiredScopes(entry, plan);
+    mergeActions(entry.actions, actions);
+    entry.scheduled += 1;
+    const currentLane = lane;
+    const work = currentLane.tail.then(async () => {
+      try {
+        await drainEntry(rootEntry(entry));
+      } finally {
+        const current = rootEntry(entry);
+        current.scheduled = Math.max(0, current.scheduled - 1);
+        current.touchedAt = now();
+        prune();
+      }
+    });
+    currentLane.tail = work.catch(() => {});
+    await work;
+  };
+
+  return {
+    activateWorkflow(workflowId: string | null) {
+      if (activeWorkflowId === workflowId) return;
+      clear();
+      activeWorkflowId = workflowId;
+      generation += 1;
+      lane = { generation, tail: Promise.resolve() };
+    },
+    clearWorkflow(workflowId: string | null) {
+      if (workflowId !== null && activeWorkflowId !== workflowId) return;
+      clear();
+      if (activeWorkflowId === workflowId) activeWorkflowId = null;
+      generation += 1;
+      lane = { generation, tail: Promise.resolve() };
+    },
+    coordinate,
+    dispose() {
+      clear();
+      activeWorkflowId = null;
+      generation += 1;
+      lane = { generation, tail: Promise.resolve() };
+    },
+  };
+}

--- a/apps/web/src/features/workflow/types.ts
+++ b/apps/web/src/features/workflow/types.ts
@@ -65,6 +65,7 @@ export type WorkflowNodeData = {
   outputPorts: NodePort[];
   onOpenMedia?: (asset: UploadedAsset) => void;
   onSelectDynamicItem?: (nodeId: string, itemId: string) => void;
+  onOpenScreenplay?: (trigger: HTMLElement) => void;
   projectId?: string | null;
   workflowId?: string | null;
   version?: number;

--- a/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayDrawer.tsx
+++ b/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayDrawer.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { CloseIcon, DocumentIcon, HistoryIcon, SaveIcon } from "../../../../icons.tsx";
+import { V2ScreenplaySceneEditor } from "./V2ScreenplaySceneEditor.tsx";
+import { validateEditableScript } from "./screenplayModel.ts";
+import { nextFocusableIndex, nextTabIndex, selectionGate, summarizeValidationIssues, versionSelectionFocusTarget, type ScreenplayProductOption, type ScreenplayVersionTarget } from "./screenplayUiHelpers.ts";
+import { V2ScreenplayVersionHistory } from "./V2ScreenplayVersionHistory.tsx";
+import type { V2ScreenplayController } from "./useV2ScreenplayController.ts";
+
+type Operation =
+  | { kind: "initial_load" }
+  | { kind: "selected_refresh" }
+  | { kind: "history_refresh" }
+  | { kind: "confirm" }
+  | { kind: "select"; target: ScreenplayVersionTarget };
+
+type Props = {
+  controller: V2ScreenplayController;
+  productOptions?: readonly ScreenplayProductOption[];
+  returnFocusRef?: RefObject<HTMLElement | null>;
+  returnFocusElement?: HTMLElement | null;
+};
+
+const tabs = ["editor", "history"] as const;
+type Tab = typeof tabs[number];
+const focusableSelector = "button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+export function V2ScreenplayDrawer({ controller, productOptions = [], returnFocusRef, returnFocusElement }: Props) {
+  const { state } = controller;
+  const [tab, setTab] = useState<Tab>("editor");
+  const [pendingVersion, setPendingVersion] = useState<ScreenplayVersionTarget | null>(null);
+  const [lastFailedOperation, setLastFailedOperation] = useState<Operation | null>(null);
+  const drawerRef = useRef<HTMLElement>(null);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const wasOpenRef = useRef(false);
+  const dialogReturnFocusRef = useRef<HTMLElement | null>(null);
+  const selectionTriggerRef = useRef<HTMLElement | null>(null);
+  const wasSelectingRef = useRef(false);
+  const requestedOperationRef = useRef<Operation | null>(null);
+
+  useEffect(() => {
+    if (state.isOpen) {
+      wasOpenRef.current = true;
+      headingRef.current?.focus();
+      return;
+    }
+    if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      (returnFocusElement ?? returnFocusRef?.current)?.focus();
+    }
+  }, [returnFocusElement, returnFocusRef, state.isOpen]);
+
+  useEffect(() => {
+    if (!state.requestError) return;
+    setLastFailedOperation(operationForRequest(state.requestError.operation, requestedOperationRef.current));
+  }, [state.requestError]);
+
+  useEffect(() => {
+    const selectionFinished = wasSelectingRef.current && !state.isSelecting;
+    wasSelectingRef.current = state.isSelecting;
+    if (!selectionFinished) return;
+    const trigger = selectionTriggerRef.current;
+    selectionTriggerRef.current = null;
+    const failed = state.requestError?.operation === "select";
+    const triggerEnabled = trigger instanceof HTMLButtonElement && !trigger.disabled && document.contains(trigger);
+    requestAnimationFrame(() => {
+      if (versionSelectionFocusTarget({ failed, triggerEnabled }) === "trigger") trigger?.focus();
+      else (tabRefs.current[1] ?? headingRef.current)?.focus();
+    });
+  }, [state.isSelecting, state.requestError]);
+
+  useEffect(() => {
+    if (!state.isOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || pendingVersion || state.closeState === "confirmation_required") return;
+      event.preventDefault();
+      dialogReturnFocusRef.current = activeElement();
+      controller.close();
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [controller, pendingVersion, state.closeState, state.isOpen]);
+
+  useEffect(() => {
+    const drawer = drawerRef.current;
+    if (!state.isOpen || !drawer) return;
+    const trapFocus = (event: KeyboardEvent) => trapTabFocus(drawer, event, headingRef.current);
+    drawer.addEventListener("keydown", trapFocus);
+    return () => drawer.removeEventListener("keydown", trapFocus);
+  }, [state.isOpen]);
+
+  if (!state.isOpen) return null;
+  const draftMutationLocked = state.isSaving || state.isSelecting;
+  const validationIssues = summarizeValidationIssues([...new Map([
+    ...state.validationErrors,
+    ...(state.draft ? validateEditableScript(state.draft) : []),
+  ].map((issue) => [`${issue.path}:${issue.message}`, issue])).values()]);
+  const errorOperation = lastFailedOperation ?? (state.requestError ? operationForRequest(state.requestError.operation) : null);
+  const errorViolations = requestViolations(state.requestError?.details);
+
+  const requestClose = () => {
+    dialogReturnFocusRef.current = activeElement();
+    controller.close();
+  };
+
+  const runOperation = (operation: Operation) => {
+    requestedOperationRef.current = operation;
+    setLastFailedOperation(null);
+    if (operation.kind === "initial_load" || operation.kind === "selected_refresh") void controller.refreshSelected();
+    if (operation.kind === "history_refresh") void controller.refreshHistory();
+    if (operation.kind === "confirm") void controller.confirm();
+    if (operation.kind === "select") {
+      selectionTriggerRef.current ??= activeElement();
+      void controller.selectVersion(operation.target.script_version_id);
+    }
+  };
+
+  const requestVersionSelection = (target: ScreenplayVersionTarget, trigger: HTMLButtonElement) => {
+    dialogReturnFocusRef.current = trigger;
+    const decision = selectionGate(state.dirty, target);
+    if (decision.action === "confirm_discard") {
+      setPendingVersion(decision.target);
+      return;
+    }
+    runOperation({ kind: "select", target: decision.target });
+  };
+
+  const finishDialog = (action: () => void) => {
+    action();
+    const target = dialogReturnFocusRef.current;
+    dialogReturnFocusRef.current = null;
+    requestAnimationFrame(() => target?.focus());
+  };
+
+  const onTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const next = nextTabIndex(event.key, index, tabs.length);
+    if (next === null) return;
+    event.preventDefault();
+    setTab(tabs[next]);
+    tabRefs.current[next]?.focus();
+  };
+
+  return <div className="v2-screenplay-drawer-backdrop">
+    <aside ref={drawerRef} className="v2-screenplay-drawer" role="dialog" aria-modal="true" aria-labelledby="v2-screenplay-drawer-title">
+      <div className="v2-screenplay-drawer__top">
+        <header className="v2-screenplay-drawer__header">
+          <div><p>Screenplay</p><h2 id="v2-screenplay-drawer-title" ref={headingRef} tabIndex={-1}>Edit script</h2></div>
+          <button className="v2-screenplay-icon-button" type="button" aria-label="Close screenplay editor" title="Close screenplay editor" onClick={requestClose}><CloseIcon /></button>
+        </header>
+        <div className="v2-screenplay-tabs" role="tablist" aria-label="Screenplay views">
+          {tabs.map((item, index) => <button key={item} ref={(node) => { tabRefs.current[index] = node; }} id={`v2-screenplay-${item}-tab`} role="tab" type="button" tabIndex={tab === item ? 0 : -1} aria-selected={tab === item} aria-controls={`v2-screenplay-${item}-panel`} onKeyDown={(event) => onTabKeyDown(event, index)} onClick={() => setTab(item)}>{item === "editor" ? <DocumentIcon /> : <HistoryIcon />}{item === "editor" ? "Editor" : "Version history"}</button>)}
+        </div>
+      </div>
+      <div className="v2-screenplay-drawer__body">
+        {state.conflict ? <section className="v2-screenplay-conflict" role="alert"><strong>Latest script changed on the server.</strong><p>{state.conflict.message}</p><div><button className="v2-screenplay-secondary-action" type="button" onClick={() => controller.keepReviewingLocalDraft()}>Keep reviewing local draft</button><button className="v2-screenplay-danger-action" type="button" onClick={() => controller.discardLocalDraftAndReloadLatest()}>Reload and discard local draft</button></div></section> : null}
+        {state.requestError ? <RequestErrorNotice error={state.requestError.message} violations={errorViolations} operation={errorOperation} onRetry={() => { if (errorOperation) runOperation(errorOperation); }} /> : null}
+        {validationIssues.length ? <section className="v2-screenplay-validation-summary" aria-live="polite" role="status"><strong>Fix these fields before confirming:</strong><ul>{validationIssues.map((issue) => <li key={`${issue.path}:${issue.message}`}><code>{issue.path}</code>: {issue.message}</li>)}</ul></section> : null}
+        {state.isLoading && !state.draft ? <p className="v2-screenplay-status">Loading screenplay...</p> : null}
+        {tab === "editor" ? <div id="v2-screenplay-editor-panel" role="tabpanel" aria-labelledby="v2-screenplay-editor-tab">{state.draft ? <V2ScreenplaySceneEditor document={state.draft} disabled={draftMutationLocked} validationErrors={validationIssues} onChange={controller.updateDraft} productOptions={productOptions} /> : !state.isLoading ? <p className="v2-screenplay-empty">No screenplay draft is available.</p> : null}</div> : <div id="v2-screenplay-history-panel" role="tabpanel" aria-labelledby="v2-screenplay-history-tab"><V2ScreenplayVersionHistory controller={controller} pendingVersionId={pendingVersion?.script_version_id} onRequestSelect={requestVersionSelection} onRefreshHistory={() => runOperation({ kind: "history_refresh" })} /></div>}
+      </div>
+      <footer className="v2-screenplay-drawer__footer">
+        <span>{state.dirty ? "Unsaved changes" : "All changes saved"}</span>
+        <button className="v2-screenplay-confirm" type="button" disabled={!state.draft || validationIssues.length > 0 || state.isSaving || state.isSelecting || Boolean(state.conflict)} onClick={() => runOperation({ kind: "confirm" })}><SaveIcon /> {state.isSaving ? "Confirming script..." : "Confirm script"}</button>
+      </footer>
+      {state.closeState === "confirmation_required" ? <ConfirmationDialog title="Discard unsaved screenplay changes?" description="Your local draft has changes that have not been confirmed." confirmLabel="Discard changes" onCancel={() => finishDialog(() => controller.cancelClose())} onConfirm={() => finishDialog(() => controller.discardDraftAndClose())} /> : null}
+      {pendingVersion ? <ConfirmationDialog title={`Use ${pendingVersion.script_title}?`} description="Your unsaved changes will be discarded and this saved script version will become selected." confirmLabel="Use this script version" onCancel={() => finishDialog(() => setPendingVersion(null))} onConfirm={() => { const target = pendingVersion; selectionTriggerRef.current = dialogReturnFocusRef.current; dialogReturnFocusRef.current = null; setPendingVersion(null); runOperation({ kind: "select", target }); }} /> : null}
+    </aside>
+  </div>;
+}
+
+function ConfirmationDialog({ title, description, confirmLabel, onCancel, onConfirm }: { title: string; description: string; confirmLabel: string; onCancel: () => void; onConfirm: () => void }) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => { cancelRef.current?.focus(); }, []);
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+      const trapFocus = (event: KeyboardEvent) => {
+        if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); onCancel(); return; }
+        if (event.key === "Tab") event.stopPropagation();
+        trapTabFocus(dialog, event, dialog);
+      };
+    dialog.addEventListener("keydown", trapFocus);
+    return () => dialog.removeEventListener("keydown", trapFocus);
+  }, [onCancel]);
+  return <div className="v2-screenplay-discard-confirmation" role="presentation"><dialog ref={dialogRef} open role="alertdialog" aria-modal="true" aria-labelledby="v2-screenplay-confirmation-title" tabIndex={-1}><h3 id="v2-screenplay-confirmation-title">{title}</h3><p>{description}</p><div><button ref={cancelRef} className="v2-screenplay-secondary-action" type="button" onClick={onCancel}>Cancel</button><button className="v2-screenplay-danger-action" type="button" onClick={onConfirm}>{confirmLabel}</button></div></dialog></div>;
+}
+
+function RequestErrorNotice({ error, violations, operation, onRetry }: { error: string; violations: Array<{ field: string; message: string }>; operation: Operation | null; onRetry: () => void }) {
+  return <section className="v2-screenplay-request-error" role="alert"><strong>{operationLabel(operation)}</strong><p>{error}</p>{violations.map((violation) => <p key={`${violation.field}:${violation.message}`}><b>{violation.field}</b>: {violation.message}</p>)}{operation ? <button className="v2-screenplay-secondary-action" type="button" onClick={onRetry}>{retryLabel(operation)}</button> : null}</section>;
+}
+
+function operationForRequest(operation: "open" | "confirm" | "select" | "refresh_selected" | "refresh_history", requested?: Operation | null): Operation { if (operation === "select" && requested?.kind === "select") return requested; return operation === "open" ? { kind: "initial_load" } : operation === "confirm" ? { kind: "confirm" } : operation === "select" ? { kind: "select", target: { script_version_id: "", script_title: "script version" } } : operation === "refresh_history" ? { kind: "history_refresh" } : { kind: "selected_refresh" }; }
+function operationLabel(operation: Operation | null): string { return operation?.kind === "confirm" ? "Unable to confirm screenplay." : operation?.kind === "select" ? "Unable to select script version." : operation?.kind === "history_refresh" ? "Unable to refresh version history." : operation?.kind === "selected_refresh" ? "Unable to refresh selected screenplay." : "Unable to load screenplay."; }
+function retryLabel(operation: Operation): string { return operation.kind === "confirm" ? "Retry confirmation" : operation.kind === "select" ? "Retry version selection" : operation.kind === "history_refresh" ? "Retry version history" : operation.kind === "selected_refresh" ? "Retry selected screenplay refresh" : "Retry loading screenplay"; }
+function activeElement(): HTMLElement | null { return document.activeElement instanceof HTMLElement ? document.activeElement : null; }
+function focusableElements(container: HTMLElement): HTMLElement[] { return [...container.querySelectorAll<HTMLElement>(focusableSelector)].filter((element) => element.closest("fieldset:disabled") === null); }
+function trapTabFocus(container: HTMLElement, event: KeyboardEvent, fallback: HTMLElement | null): void {
+  if (event.key !== "Tab" || event.defaultPrevented) return;
+  event.preventDefault();
+  const focusable = focusableElements(container);
+  if (!focusable.length) { fallback?.focus(); return; }
+  const current = focusable.indexOf(document.activeElement as HTMLElement);
+  const next = current < 0
+    ? event.shiftKey ? focusable.length - 1 : 0
+    : nextFocusableIndex(current, focusable.length, event.shiftKey);
+  focusable[next]?.focus();
+}
+function requestViolations(details: Record<string, unknown> | undefined): Array<{ field: string; message: string }> { const raw = details?.violations; if (!Array.isArray(raw)) return []; return raw.flatMap((entry) => { if (!entry || typeof entry !== "object") return []; const value = entry as Record<string, unknown>; return typeof value.message === "string" ? [{ field: typeof value.field === "string" ? value.field : "Screenplay", message: value.message }] : []; }); }

--- a/apps/web/src/features/workflow/v2/screenplay/V2ScreenplaySceneEditor.tsx
+++ b/apps/web/src/features/workflow/v2/screenplay/V2ScreenplaySceneEditor.tsx
@@ -1,0 +1,119 @@
+import { ChevronDownIcon, ChevronUpIcon, PlusIcon, TrashIcon } from "../../../../icons.tsx";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { V2EditableScriptCharacter, V2EditableScriptDocument, V2EditableScriptLocation, V2ScriptAspectRatio } from "../../../../types-v2.ts";
+import { createEditableScene, reorderItem } from "./screenplayModel.ts";
+import { createProductBeatRows, reconcileProductBeatRows, type ProductBeatRow, type ScreenplayProductOption } from "./screenplayUiHelpers.ts";
+import { V2ScreenplayShotEditor } from "./V2ScreenplayShotEditor.tsx";
+
+type Props = {
+  document: V2EditableScriptDocument;
+  disabled: boolean;
+  validationErrors: ReadonlyArray<{ path: string; message: string }>;
+  onChange: (update: (document: V2EditableScriptDocument) => V2EditableScriptDocument) => void;
+  productOptions?: readonly ScreenplayProductOption[];
+};
+
+let clientKeyCounter = 0;
+const aspectRatios: V2ScriptAspectRatio[] = ["16:9", "9:16", "4:3", "3:4", "1:1", "21:9"];
+
+export function V2ScreenplaySceneEditor({ document, disabled, validationErrors, onChange, productOptions = [] }: Props) {
+  const characters = document.characters ?? [];
+  const locations = document.locations ?? [];
+  const change = (update: (next: V2EditableScriptDocument) => void) => onChange((next) => { update(next); return next; });
+  const setField = (field: "script_title" | "language" | "tone" | "visual_style", value: string) => change((next) => { next[field] = value; });
+
+  return <fieldset className="v2-screenplay-editor" disabled={disabled} style={{ border: 0, margin: 0, minInlineSize: 0, padding: 0 }}>
+    <section className="v2-screenplay-section" aria-labelledby="v2-screenplay-details">
+      <h3 id="v2-screenplay-details">Script details</h3>
+      <div className="v2-screenplay-fields">
+        <Field label="Script title" error={errorAt(validationErrors, "script_title")}><input value={document.script_title} onChange={(event) => setField("script_title", event.target.value)} /></Field>
+        <Field label="Language" error={errorAt(validationErrors, "language")}><input value={document.language} onChange={(event) => setField("language", event.target.value)} /></Field>
+        <Field label="Tone" error={errorAt(validationErrors, "tone")}><input value={document.tone} onChange={(event) => setField("tone", event.target.value)} /></Field>
+        <Field label="Visual style" error={errorAt(validationErrors, "visual_style")}><input value={document.visual_style} onChange={(event) => setField("visual_style", event.target.value)} /></Field>
+        <Field label="Aspect ratio" error={errorAt(validationErrors, "aspect_ratio")}><select value={document.aspect_ratio} onChange={(event) => change((next) => { next.aspect_ratio = event.target.value as V2ScriptAspectRatio; })}>{aspectRatios.map((ratio) => <option key={ratio} value={ratio}>{ratio}</option>)}</select></Field>
+      </div>
+      <ProductBeatsEditor beats={document.product_beats ?? []} onChange={(beats) => change((next) => { next.product_beats = beats; })} />
+    </section>
+    <EntitySection
+      title="Characters"
+      addLabel="Add character"
+      onAdd={() => change((next) => { next.characters = [...(next.characters ?? []), createCharacter()]; })}
+    >
+      {characters.length === 0 ? <Empty label="No characters yet." /> : characters.map((character, index) => <article className="v2-screenplay-entity" key={entityId(character)}>
+        <ItemHeading label={`Character ${index + 1}`} prefix="character" index={index} count={characters.length} onMove={(from, to) => change((next) => { next.characters = reorderItem(next.characters ?? [], from, to); })} onRemove={() => change((next) => removeCharacterReferences(next, entityId(character)))} />
+        <div className="v2-screenplay-fields">
+          <Field label="Display name" error={errorAt(validationErrors, `characters.${index}.display_name`)}><input value={character.display_name} onChange={(event) => change((next) => updateEntity(next.characters ?? [], index, (item) => { item.display_name = event.target.value; }))} /></Field>
+          <Field label="Role" error={errorAt(validationErrors, `characters.${index}.role`)}><input value={character.role} onChange={(event) => change((next) => updateEntity(next.characters ?? [], index, (item) => { item.role = event.target.value; }))} /></Field>
+          <Field label="Description" error={errorAt(validationErrors, `characters.${index}.description`)}><textarea value={character.description} onChange={(event) => change((next) => updateEntity(next.characters ?? [], index, (item) => { item.description = event.target.value; }))} /></Field>
+          <Field label="Visual notes" error={errorAt(validationErrors, `characters.${index}.visual_notes`)}><textarea value={character.visual_notes} onChange={(event) => change((next) => updateEntity(next.characters ?? [], index, (item) => { item.visual_notes = event.target.value; }))} /></Field>
+          <Field label="Gender"><input value={character.gender ?? ""} onChange={(event) => change((next) => updateEntity(next.characters ?? [], index, (item) => { item.gender = event.target.value || null; }))} /></Field>
+        </div>
+      </article>)}
+    </EntitySection>
+    <EntitySection title="Locations" addLabel="Add location" onAdd={() => change((next) => { next.locations = [...(next.locations ?? []), createLocation()]; })}>
+      {locations.length === 0 ? <Empty label="No locations yet." /> : locations.map((location, index) => <article className="v2-screenplay-entity" key={entityId(location)}>
+        <ItemHeading label={`Location ${index + 1}`} prefix="location" index={index} count={locations.length} onMove={(from, to) => change((next) => { next.locations = reorderItem(next.locations ?? [], from, to); })} onRemove={() => change((next) => removeLocationReferences(next, entityId(location)))} />
+        <div className="v2-screenplay-fields">
+          <Field label="Display name" error={errorAt(validationErrors, `locations.${index}.display_name`)}><input value={location.display_name} onChange={(event) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.display_name = event.target.value; }))} /></Field>
+          <Field label="Description" error={errorAt(validationErrors, `locations.${index}.description`)}><textarea value={location.description} onChange={(event) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.description = event.target.value; }))} /></Field>
+          <Field label="Visual notes" error={errorAt(validationErrors, `locations.${index}.visual_notes`)}><textarea value={location.visual_notes} onChange={(event) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.visual_notes = event.target.value; }))} /></Field>
+          <Field label="Location type"><input value={location.location_type ?? ""} onChange={(event) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.location_type = event.target.value || null; }))} /></Field>
+          <Field label="Time of day"><input value={location.time_of_day ?? ""} onChange={(event) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.time_of_day = event.target.value || null; }))} /></Field>
+          <SettingField value={location.setting_type ?? ""} error={errorAt(validationErrors, `locations.${index}.setting_type`)} onChange={(value) => change((next) => updateEntity(next.locations ?? [], index, (item) => { item.setting_type = value; }))} />
+        </div>
+      </article>)}
+    </EntitySection>
+    <EntitySection title="Scenes" addLabel="Add scene" onAdd={() => change((next) => { next.scenes.push(createEditableScene()); })}>
+      {document.scenes.length === 0 ? <Empty label="No scenes yet." error={errorAt(validationErrors, "scenes")} /> : document.scenes.map((scene, index) => <article className="v2-screenplay-scene" key={entityId(scene)}>
+        <ItemHeading label={`Scene ${index + 1}`} prefix="scene" index={index} count={document.scenes.length} onMove={(from, to) => change((next) => { next.scenes = reorderItem(next.scenes, from, to); })} onRemove={() => change((next) => removeSceneReferences(next, entityId(scene)))} />
+        <div className="v2-screenplay-fields">
+          <Field label="Scene title" error={errorAt(validationErrors, `scenes.${index}.title`)}><input value={scene.title} onChange={(event) => change((next) => updateEntity(next.scenes, index, (item) => { item.title = event.target.value; }))} /></Field>
+          <Field label="Scene description" error={errorAt(validationErrors, `scenes.${index}.description`)}><textarea value={scene.description} onChange={(event) => change((next) => updateEntity(next.scenes, index, (item) => { item.description = event.target.value; }))} /></Field>
+          <Field label="Location" error={errorAt(validationErrors, `scenes.${index}.location_id`)}><select value={scene.location_id ?? ""} onChange={(event) => change((next) => updateEntity(next.scenes, index, (item) => { item.location_id = event.target.value || null; }))}><option value="">No location</option>{locations.map((location) => <option key={entityId(location)} value={entityId(location)}>{location.display_name || "Untitled location"}</option>)}</select></Field>
+          <Field label="Location type"><input value={scene.location_type ?? ""} onChange={(event) => change((next) => updateEntity(next.scenes, index, (item) => { item.location_type = event.target.value || null; }))} /></Field>
+          <Field label="Time of day"><input value={scene.time_of_day ?? ""} onChange={(event) => change((next) => updateEntity(next.scenes, index, (item) => { item.time_of_day = event.target.value || null; }))} /></Field>
+          <SettingField value={scene.setting_type ?? ""} error={errorAt(validationErrors, `scenes.${index}.setting_type`)} onChange={(value) => change((next) => updateEntity(next.scenes, index, (item) => { item.setting_type = value; }))} />
+        </div>
+        <V2ScreenplayShotEditor document={document} sceneIndex={index} validationErrors={validationErrors} onChange={onChange} productOptions={productOptions} />
+      </article>)}
+    </EntitySection>
+  </fieldset>;
+}
+
+function EntitySection({ title, addLabel, onAdd, children }: { title: string; addLabel: string; onAdd: () => void; children: ReactNode }) { return <section className="v2-screenplay-section"><div className="v2-screenplay-section-heading"><h3>{title}</h3><button className="v2-screenplay-add" type="button" onClick={onAdd}><PlusIcon /> {addLabel}</button></div>{children}</section>; }
+function Empty({ label, error }: { label: string; error?: string }) { return <p className="v2-screenplay-empty">{label}{error ? <em>{error}</em> : null}</p>; }
+function Field({ label, error, children }: { label: string; error?: string; children: ReactNode }) { return <label className="v2-screenplay-field"><span>{label}</span>{children}{error ? <em>{error}</em> : null}</label>; }
+function SettingField({ value, error, onChange }: { value: "" | "interior" | "exterior"; error?: string; onChange: (value: "interior" | "exterior" | null) => void }) { return <Field label="Setting" error={error}><select value={value} onChange={(event) => onChange((event.target.value || null) as "interior" | "exterior" | null)}><option value="">Unspecified</option><option value="interior">Interior</option><option value="exterior">Exterior</option></select></Field>; }
+function ProductBeatsEditor({ beats, onChange }: { beats: string[]; onChange: (beats: string[]) => void }) {
+  const sequence = useRef(0);
+  const createKey = () => `product-beat-ui-${++sequence.current}`;
+  const [rows, setRows] = useState<ProductBeatRow[]>(() => createProductBeatRows(beats, createKey));
+
+  useEffect(() => {
+    setRows((current) => current.map((row) => row.value).join("\u0000") === beats.join("\u0000")
+      ? current
+      : reconcileProductBeatRows(current, beats, createKey));
+  }, [beats]);
+
+  const publish = (next: ProductBeatRow[]) => {
+    setRows(next);
+    onChange(next.map((row) => row.value));
+  };
+
+  return <section className="v2-screenplay-product-beats"><div className="v2-screenplay-section-heading"><h4>Product beats</h4><button className="v2-screenplay-add" type="button" onClick={() => publish([...rows, { key: createKey(), value: "Describe the product beat." }])}><PlusIcon /> Add product beat</button></div>{rows.length === 0 ? <Empty label="No product beats yet." /> : rows.map((row, index) => <div className="v2-screenplay-beat" key={row.key}><ItemHeading label={`Product beat ${index + 1}`} prefix="product beat" index={index} count={rows.length} onMove={(from, to) => publish(reorderItem(rows, from, to))} onRemove={() => publish(rows.filter((_, itemIndex) => itemIndex !== index))} /><Field label="Product beat"><textarea value={row.value} onChange={(event) => publish(rows.map((item, itemIndex) => itemIndex === index ? { ...item, value: event.target.value } : item))} /></Field></div>)}</section>;
+}
+function ItemHeading({ label, prefix, index, count, onMove, onRemove }: { label: string; prefix: string; index: number; count: number; onMove: (from: number, to: number) => void; onRemove: () => void }) { return <div className="v2-screenplay-item-heading"><strong>{label}</strong><div className="v2-screenplay-icon-actions"><button type="button" aria-label={`Move ${prefix} up`} title={`Move ${label} up`} disabled={index === 0} onClick={() => onMove(index, index - 1)}><ChevronUpIcon /></button><button type="button" aria-label={`Move ${prefix} down`} title={`Move ${label} down`} disabled={index === count - 1} onClick={() => onMove(index, index + 1)}><ChevronDownIcon /></button><button type="button" aria-label={`Remove ${prefix}`} title={`Remove ${label}`} onClick={onRemove}><TrashIcon /></button></div></div>; }
+function updateEntity<T>(items: T[], index: number, update: (item: T) => void) { if (items[index]) update(items[index]); }
+function errorAt(errors: ReadonlyArray<{ path: string; message: string }>, path: string): string | undefined { return errors.find((error) => error.path === path || error.path.startsWith(`${path}.`))?.message; }
+function entityId(item: { client_key?: string | null; character_id?: string | null; location_id?: string | null; scene_id?: string | null }): string { return item.client_key ?? item.character_id ?? item.location_id ?? item.scene_id ?? "new-item"; }
+function clientKey(namespace: string) { clientKeyCounter += 1; return `${namespace}-client-ui-${clientKeyCounter}`; }
+function createCharacter(): V2EditableScriptCharacter { return { client_key: clientKey("character"), display_name: "New character", role: "supporting", description: "Describe the character.", visual_notes: "Describe visual details.", gender: null }; }
+function createLocation(): V2EditableScriptLocation { return { client_key: clientKey("location"), display_name: "New location", description: "Describe the location.", visual_notes: "Describe visual details.", location_type: null, time_of_day: null, setting_type: null }; }
+
+function removeCharacterReferences(document: V2EditableScriptDocument, characterId: string) {
+  document.characters = (document.characters ?? []).filter((character) => entityId(character) !== characterId);
+  document.scenes.forEach((scene) => scene.shots.forEach((shot) => { shot.character_ids = (shot.character_ids ?? []).filter((id) => id !== characterId); shot.dialogue = (shot.dialogue ?? []).filter((line) => line.character_id !== characterId); }));
+  return document;
+}
+function removeLocationReferences(document: V2EditableScriptDocument, locationId: string) { document.locations = (document.locations ?? []).filter((location) => entityId(location) !== locationId); document.scenes.forEach((scene) => { if (scene.location_id === locationId) scene.location_id = null; }); return document; }
+function removeSceneReferences(document: V2EditableScriptDocument, sceneId: string) { document.scenes = document.scenes.filter((scene) => entityId(scene) !== sceneId); document.scenes.forEach((scene) => scene.shots.forEach((shot) => { shot.scene_ids = (shot.scene_ids ?? []).filter((id) => id !== sceneId); })); return document; }

--- a/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayShotEditor.tsx
+++ b/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayShotEditor.tsx
@@ -1,0 +1,189 @@
+import { ChevronDownIcon, ChevronUpIcon, PlusIcon, TrashIcon } from "../../../../icons.tsx";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type {
+  V2EditableScriptDialogue,
+  V2EditableScriptDocument,
+  V2EditableScriptShot,
+} from "../../../../types-v2.ts";
+import { createEditableDialogue, createEditableShot, reorderItem } from "./screenplayModel.ts";
+import { draftDurationValue, mergeProductOptions, parsePositiveDuration, type ScreenplayProductOption } from "./screenplayUiHelpers.ts";
+
+type Props = {
+  document: V2EditableScriptDocument;
+  sceneIndex: number;
+  validationErrors: ReadonlyArray<{ path: string; message: string }>;
+  onChange: (update: (document: V2EditableScriptDocument) => V2EditableScriptDocument) => void;
+  productOptions?: readonly ScreenplayProductOption[];
+};
+
+export function V2ScreenplayShotEditor({ document, sceneIndex, validationErrors, onChange, productOptions = [] }: Props) {
+  const scene = document.scenes[sceneIndex];
+  if (!scene) return null;
+  const sceneIdentity = entityId(scene);
+  const characterOptions = (document.characters ?? []).map((character) => ({ value: entityId(character), label: character.display_name || "Untitled character" }));
+  const sceneOptions = document.scenes.map((entry) => ({ value: entityId(entry), label: entry.title || "Untitled scene" }));
+  const availableProductOptions = mergeProductOptions(productOptions, document.scenes.flatMap((entry) => entry.shots.flatMap((shot) => shot.product_ids ?? [])));
+
+  const changeShot = (shotIndex: number, update: (shot: V2EditableScriptShot) => void) => onChange((next) => {
+    const shot = next.scenes[sceneIndex]?.shots[shotIndex];
+    if (shot) update(shot);
+    return next;
+  });
+
+  const moveShot = (from: number, to: number) => onChange((next) => {
+    const target = next.scenes[sceneIndex];
+    if (target) target.shots = reorderItem(target.shots, from, to);
+    return next;
+  });
+
+  const removeShot = (shotIndex: number) => onChange((next) => {
+    const target = next.scenes[sceneIndex];
+    if (target) target.shots.splice(shotIndex, 1);
+    return next;
+  });
+
+  const addShot = () => onChange((next) => {
+    const target = next.scenes[sceneIndex];
+    if (target) target.shots.push(createEditableShot(entityId(target)));
+    return next;
+  });
+
+  return (
+    <section className="v2-screenplay-shots" aria-label={`Shots for ${scene.title || "scene"}`}>
+      <div className="v2-screenplay-section-heading">
+        <h4>Shots</h4>
+        <button className="v2-screenplay-add" type="button" onClick={addShot}>
+          <PlusIcon /> Add shot
+        </button>
+      </div>
+      {scene.shots.length === 0 ? <p className="v2-screenplay-empty">No shots yet.{errorAt(validationErrors, `scenes.${sceneIndex}.shots`) ? <em>{errorAt(validationErrors, `scenes.${sceneIndex}.shots`)}</em> : null}</p> : null}
+      {scene.shots.map((shot, shotIndex) => {
+        const path = `scenes.${sceneIndex}.shots.${shotIndex}`;
+        return (
+          <article className="v2-screenplay-shot" key={entityId(shot)}>
+            <div className="v2-screenplay-item-heading">
+              <strong>Shot {shotIndex + 1}</strong>
+              <IconActions
+                prefix="shot"
+                index={shotIndex}
+                count={scene.shots.length}
+                onMove={moveShot}
+                onRemove={() => removeShot(shotIndex)}
+              />
+            </div>
+            <div className="v2-screenplay-fields">
+              <Field label="Shot description / action" error={errorAt(validationErrors, `${path}.description`)}>
+                <textarea value={shot.description} onChange={(event) => changeShot(shotIndex, (next) => { next.description = event.target.value; })} />
+              </Field>
+              <Field label="Visual prompt" error={errorAt(validationErrors, `${path}.visual_prompt`)}>
+                <textarea value={shot.visual_prompt} onChange={(event) => changeShot(shotIndex, (next) => { next.visual_prompt = event.target.value; })} />
+              </Field>
+              <DurationField value={shot.duration_seconds} error={errorAt(validationErrors, `${path}.duration_seconds`)} onCommit={(duration) => changeShot(shotIndex, (next) => { next.duration_seconds = duration; })} />
+              <Field label="Narration">
+                <textarea value={shot.narration ?? ""} onChange={(event) => changeShot(shotIndex, (next) => { next.narration = event.target.value || null; })} />
+              </Field>
+              <ReferenceSelect label="Product references" options={availableProductOptions.map((option) => ({ value: option.id, label: option.label ?? option.id }))} value={shot.product_ids ?? []} onChange={(values) => changeShot(shotIndex, (next) => { next.product_ids = values; })} />
+              <ReferenceSelect label="Character references" options={characterOptions} value={shot.character_ids ?? []} error={errorAt(validationErrors, `${path}.character_ids`)} onChange={(values) => changeShot(shotIndex, (next) => { next.character_ids = values; })} />
+              <ReferenceSelect label="Scene references" options={sceneOptions} value={shot.scene_ids ?? [sceneIdentity]} error={errorAt(validationErrors, `${path}.scene_ids`)} onChange={(values) => changeShot(shotIndex, (next) => { next.scene_ids = values; })} />
+            </div>
+            <DialogueEditor
+              dialogue={shot.dialogue ?? []}
+              characterOptions={characterOptions}
+              validationErrors={validationErrors}
+              path={path}
+              onChange={(update) => changeShot(shotIndex, (next) => { next.dialogue = update(next.dialogue ?? []); })}
+            />
+          </article>
+        );
+      })}
+    </section>
+  );
+}
+
+function DialogueEditor({ dialogue, characterOptions, validationErrors, path, onChange }: {
+  dialogue: V2EditableScriptDialogue[];
+  characterOptions: Array<{ value: string; label: string }>;
+  validationErrors: ReadonlyArray<{ path: string; message: string }>;
+  path: string;
+  onChange: (update: (dialogue: V2EditableScriptDialogue[]) => V2EditableScriptDialogue[]) => void;
+}) {
+  return <section className="v2-screenplay-dialogue">
+    <div className="v2-screenplay-section-heading">
+      <h5>Dialogue</h5>
+      <button className="v2-screenplay-add" type="button" disabled={!characterOptions.length} onClick={() => onChange((items) => [...items, createEditableDialogue(characterOptions[0].value)])}>
+        <PlusIcon /> Add dialogue
+      </button>
+    </div>
+    {!characterOptions.length ? <p className="v2-screenplay-hint">Add a character before adding dialogue.</p> : null}
+    {dialogue.map((line, dialogueIndex) => <div className="v2-screenplay-dialogue-line" key={entityId(line)}>
+      <div className="v2-screenplay-item-heading">
+        <strong>Line {dialogueIndex + 1}</strong>
+        <IconActions prefix="dialogue" index={dialogueIndex} count={dialogue.length} onMove={(from, to) => onChange((items) => reorderItem(items, from, to))} onRemove={() => onChange((items) => items.filter((_, index) => index !== dialogueIndex))} />
+      </div>
+      <div className="v2-screenplay-fields v2-screenplay-fields--compact">
+        <Field label="Character" error={errorAt(validationErrors, `${path}.dialogue.${dialogueIndex}.character_id`)}>
+          <select value={line.character_id} onChange={(event) => onChange((items) => updateDialogue(items, dialogueIndex, (next) => { next.character_id = event.target.value; }))}>
+            <option value="">Choose character</option>
+            {characterOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+        </Field>
+        <Field label="Performance cue">
+          <input value={line.performance_cue ?? ""} onChange={(event) => onChange((items) => updateDialogue(items, dialogueIndex, (next) => { next.performance_cue = event.target.value || null; }))} />
+        </Field>
+        <Field label="Text" error={errorAt(validationErrors, `${path}.dialogue.${dialogueIndex}.text`)}>
+          <textarea value={line.text} onChange={(event) => onChange((items) => updateDialogue(items, dialogueIndex, (next) => { next.text = event.target.value; }))} />
+        </Field>
+      </div>
+    </div>)}
+  </section>;
+}
+
+function updateDialogue(items: V2EditableScriptDialogue[], index: number, update: (item: V2EditableScriptDialogue) => void) {
+  const next = [...items];
+  if (next[index]) update(next[index]);
+  return next;
+}
+
+function ReferenceSelect({ label, options, value, error, onChange }: { label: string; options: Array<{ value: string; label: string }>; value: string[]; error?: string; onChange: (value: string[]) => void }) {
+  return <Field label={label} error={error}>
+    <select multiple value={value} onChange={(event) => onChange([...event.currentTarget.selectedOptions].map((option) => option.value))}>
+      {options.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+    </select>
+  </Field>;
+}
+
+function DurationField({ value, error, onCommit }: { value: number; error?: string; onCommit: (value: number) => void }) {
+  const [text, setText] = useState(String(value));
+  const [touched, setTouched] = useState(false);
+  const editingRef = useRef(false);
+  useEffect(() => { if (!editingRef.current) setText(String(value)); }, [value]);
+  const localError = touched && parsePositiveDuration(text) === null ? "Enter a positive whole-number duration." : undefined;
+  const commitOnBlur = () => {
+    editingRef.current = false;
+    setTouched(true);
+  };
+  return <Field label="Duration (seconds)" error={error ?? localError}>
+    <input title="Enter a positive duration in seconds" min="1" step="1" inputMode="numeric" type="number" value={text} onChange={(event) => { const nextText = event.target.value; editingRef.current = true; setText(nextText); const duration = draftDurationValue(nextText, value); if (parsePositiveDuration(nextText) === null) setTouched(true); if (duration !== value) onCommit(duration); }} onBlur={commitOnBlur} />
+  </Field>;
+}
+
+function IconActions({ prefix, index, count, onMove, onRemove }: { prefix: string; index: number; count: number; onMove: (from: number, to: number) => void; onRemove: () => void }) {
+  const item = prefix[0].toUpperCase() + prefix.slice(1);
+  return <div className="v2-screenplay-icon-actions">
+    <button type="button" aria-label={`Move ${prefix} up`} title={`Move ${item} up`} disabled={index === 0} onClick={() => onMove(index, index - 1)}><ChevronUpIcon /></button>
+    <button type="button" aria-label={`Move ${prefix} down`} title={`Move ${item} down`} disabled={index === count - 1} onClick={() => onMove(index, index + 1)}><ChevronDownIcon /></button>
+    <button type="button" aria-label={`Remove ${prefix}`} title={`Remove ${item}`} onClick={onRemove}><TrashIcon /></button>
+  </div>;
+}
+
+function Field({ label, error, children }: { label: string; error?: string; children: ReactNode }) {
+  return <label className="v2-screenplay-field"><span>{label}</span>{children}{error ? <em>{error}</em> : null}</label>;
+}
+
+function errorAt(errors: ReadonlyArray<{ path: string; message: string }>, path: string): string | undefined {
+  return errors.find((error) => error.path === path || error.path.startsWith(`${path}.`))?.message;
+}
+
+function entityId(item: { client_key?: string | null; scene_id?: string | null; shot_id?: string | null; dialogue_id?: string | null }): string {
+  return item.client_key ?? item.scene_id ?? item.shot_id ?? item.dialogue_id ?? "new-item";
+}

--- a/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayVersionHistory.tsx
+++ b/apps/web/src/features/workflow/v2/screenplay/V2ScreenplayVersionHistory.tsx
@@ -1,0 +1,48 @@
+import { HistoryIcon, SyncIcon } from "../../../../icons.tsx";
+import type { V2ScriptVersionSummary } from "../../../../types-v2.ts";
+import type { ScreenplayVersionTarget } from "./screenplayUiHelpers.ts";
+import type { V2ScreenplayController } from "./useV2ScreenplayController.ts";
+
+type Props = {
+  controller: V2ScreenplayController;
+  pendingVersionId?: string | null;
+  onRequestSelect: (target: ScreenplayVersionTarget, trigger: HTMLButtonElement) => void;
+  onRefreshHistory?: () => void;
+};
+
+export function V2ScreenplayVersionHistory({ controller, pendingVersionId = null, onRequestSelect, onRefreshHistory }: Props) {
+  const { state } = controller;
+  const versions = [...state.versions].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  const selecting = state.isSelecting;
+
+  return <section className="v2-screenplay-history" aria-label="Script version history">
+    <div className="v2-screenplay-section-heading">
+      <div><h3>Version history</h3><p>Immutable saved script versions.</p></div>
+      <button className="v2-screenplay-icon-button" type="button" aria-label="Refresh script version history" title="Refresh script version history" disabled={state.isLoading || selecting} onClick={() => onRefreshHistory ? onRefreshHistory() : void controller.refreshHistory()}><SyncIcon /></button>
+    </div>
+    {state.isLoading && versions.length === 0 ? <p className="v2-screenplay-status">Loading script versions...</p> : null}
+    {!state.isLoading && versions.length === 0 ? <p className="v2-screenplay-empty">No script versions are available.</p> : null}
+    {versions.map((version) => <VersionRow key={version.script_version_id} version={version} selected={version.script_version_id === state.selectedScriptVersionId} pending={version.script_version_id === pendingVersionId} disabled={selecting || Boolean(state.conflict) || Boolean(pendingVersionId)} onSelect={(trigger) => onRequestSelect(toTarget(version), trigger)} />)}
+  </section>;
+}
+
+function VersionRow({ version, selected, pending, disabled, onSelect }: { version: V2ScriptVersionSummary; selected: boolean; pending: boolean; disabled: boolean; onSelect: (trigger: HTMLButtonElement) => void }) {
+  return <article className={`v2-screenplay-version ${selected ? "is-selected" : ""}`}>
+    <div className="v2-screenplay-version-heading"><HistoryIcon /><div><strong>{version.script_title || "Untitled script"}</strong><span>{selected ? "Selected" : pending ? "Awaiting confirmation" : "Saved version"}</span></div></div>
+    <dl>
+      <div><dt>Source</dt><dd>{sourceLabel(version.source_action)}</dd></div>
+      <div><dt>Created</dt><dd>{formatTimestamp(version.created_at)}</dd></div>
+      <div><dt>Changes</dt><dd>{formatDiffSummary(version.structural_diff_summary)}</dd></div>
+    </dl>
+    <button className="v2-screenplay-secondary-action" type="button" disabled={selected || disabled} onClick={(event) => onSelect(event.currentTarget)}>{pending ? "Awaiting confirmation..." : disabled && !selected ? "Applying version..." : "Use this script version"}</button>
+  </article>;
+}
+
+function toTarget(version: V2ScriptVersionSummary): ScreenplayVersionTarget { return { script_version_id: version.script_version_id, script_title: version.script_title || "Untitled script" }; }
+function sourceLabel(source: V2ScriptVersionSummary["source_action"]): string { return source === "script_editor_confirm" ? "Editor confirmation" : source === "agent_chat_edit" ? "Agent edit" : "Initial planning"; }
+function formatTimestamp(value: string): string { const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString(); }
+function formatDiffSummary(summary: Record<string, unknown>): string {
+  const entries = Object.entries(summary).filter(([, value]) => value !== 0 && value !== false && value != null);
+  if (!entries.length) return "No structural changes recorded.";
+  return entries.map(([key, value]) => `${key.replace(/_/g, " ")}: ${typeof value === "object" ? JSON.stringify(value) : String(value)}`).join("; ");
+}

--- a/apps/web/src/features/workflow/v2/screenplay/screenplayModel.ts
+++ b/apps/web/src/features/workflow/v2/screenplay/screenplayModel.ts
@@ -1,0 +1,379 @@
+import type {
+  V2EditableScriptCharacter,
+  V2EditableScriptDialogue,
+  V2EditableScriptDocument,
+  V2EditableScriptLocation,
+  V2EditableScriptScene,
+  V2EditableScriptShot,
+  V2ScriptAspectRatio,
+  V2ScriptPlan,
+} from "../../../../types-v2.ts";
+
+const supportedAspectRatios = new Set<V2ScriptAspectRatio>(["16:9", "9:16", "4:3", "3:4", "1:1", "21:9"]);
+
+let nextClientKey = 0;
+
+export interface EditableScriptValidationIssue {
+  path: string;
+  message: string;
+}
+
+export class CanonicalScreenplayOrderError extends Error {
+  readonly code = "inconsistent_canonical_screenplay_order";
+
+  constructor() {
+    super("Canonical scene and shot order cannot preserve the canonical flat shot order in an editable document.");
+    this.name = "CanonicalScreenplayOrderError";
+  }
+}
+
+export function scriptToEditableDocument(script: V2ScriptPlan): V2EditableScriptDocument {
+  assertEditableOrderCanPreserveCanonicalOrder(script);
+  const shotsByScene = new Map<string, V2EditableScriptShot[]>();
+
+  for (const shot of script.shots) {
+    const editableShot: V2EditableScriptShot = {
+      shot_id: shot.shot_id,
+      product_ids: [...shot.product_ids],
+      character_ids: [...shot.character_ids],
+      scene_ids: [...shot.scene_ids],
+      description: shot.description,
+      dialogue: shot.dialogue.map((line) => ({
+        dialogue_id: line.dialogue_id,
+        character_id: line.character_id,
+        performance_cue: line.performance_cue,
+        text: line.text,
+      })),
+      narration: shot.narration,
+      visual_prompt: shot.visual_prompt,
+      duration_seconds: shot.duration_seconds,
+    };
+    const sceneShots = shotsByScene.get(shot.scene_id) ?? [];
+    sceneShots.push(editableShot);
+    shotsByScene.set(shot.scene_id, sceneShots);
+  }
+
+  return {
+    script_title: script.script_title,
+    language: script.language,
+    characters: script.characters.map(toEditableCharacter),
+    locations: script.locations.map(toEditableLocation),
+    scenes: script.scenes.map((scene) => ({
+      scene_id: scene.scene_id,
+      title: scene.title,
+      description: scene.description,
+      location_id: scene.location_id,
+      location_type: scene.location_type,
+      time_of_day: scene.time_of_day,
+      setting_type: scene.setting_type,
+      shots: shotsByScene.get(scene.scene_id) ?? [],
+    })),
+    product_beats: [...script.product_beats],
+    tone: script.tone,
+    visual_style: script.visual_style,
+    aspect_ratio: script.aspect_ratio,
+  };
+}
+
+export function createEditableScene(): V2EditableScriptScene {
+  return {
+    client_key: createClientKey("scene"),
+    title: "New scene",
+    description: "Describe the scene.",
+    shots: [],
+  };
+}
+
+export function createEditableShot(sceneId: string): V2EditableScriptShot {
+  return {
+    client_key: createClientKey("shot"),
+    product_ids: [],
+    character_ids: [],
+    scene_ids: [sceneId],
+    description: "Describe the shot.",
+    dialogue: [],
+    narration: null,
+    visual_prompt: "Describe the visual.",
+    duration_seconds: 1,
+  };
+}
+
+export function createEditableDialogue(characterId: string): V2EditableScriptDialogue {
+  return {
+    client_key: createClientKey("dialogue"),
+    character_id: characterId,
+    performance_cue: null,
+    text: "Add dialogue.",
+  };
+}
+
+export function reorderItem<T>(items: T[], from: number, to: number): T[] {
+  if (!isArrayIndex(from, items.length) || !isArrayIndex(to, items.length) || from === to) {
+    return items;
+  }
+
+  const reordered = [...items];
+  const [item] = reordered.splice(from, 1);
+  reordered.splice(to, 0, item);
+  return reordered;
+}
+
+export function validateEditableScript(document: V2EditableScriptDocument): EditableScriptValidationIssue[] {
+  const issues: EditableScriptValidationIssue[] = [];
+  const characters = document.characters ?? [];
+  const locations = document.locations ?? [];
+  const scenes = document.scenes ?? [];
+
+  validateRequiredText(issues, "script_title", document.script_title);
+  validateRequiredText(issues, "language", document.language);
+  validateRequiredText(issues, "tone", document.tone);
+  validateRequiredText(issues, "visual_style", document.visual_style);
+  if (!supportedAspectRatios.has(document.aspect_ratio)) {
+    addIssue(issues, "aspect_ratio", "Choose a supported aspect ratio.");
+  }
+
+  const characterIds = collectEntityIds(issues, characters, "character", "character_id", "characters");
+  const locationIds = collectEntityIds(issues, locations, "location", "location_id", "locations");
+  const sceneIds = collectEntityIds(issues, scenes, "scene", "scene_id", "scenes");
+
+  characters.forEach((character, index) => {
+    validateRequiredText(issues, `characters.${index}.display_name`, character.display_name);
+    validateRequiredText(issues, `characters.${index}.description`, character.description);
+    validateRequiredText(issues, `characters.${index}.role`, character.role);
+    validateRequiredText(issues, `characters.${index}.visual_notes`, character.visual_notes);
+  });
+  locations.forEach((location, index) => {
+    validateRequiredText(issues, `locations.${index}.display_name`, location.display_name);
+    validateRequiredText(issues, `locations.${index}.description`, location.description);
+    validateRequiredText(issues, `locations.${index}.visual_notes`, location.visual_notes);
+    validateSettingType(issues, `locations.${index}.setting_type`, location.setting_type);
+  });
+
+  if (scenes.length === 0) {
+    addIssue(issues, "scenes", "Add at least one scene.");
+  }
+
+  const shotIdentities: Array<{ item: V2EditableScriptShot; path: string }> = [];
+  const dialogueIdentities: Array<{ item: V2EditableScriptDialogue; path: string }> = [];
+  scenes.forEach((scene, sceneIndex) => {
+    const scenePath = `scenes.${sceneIndex}`;
+    validateRequiredText(issues, `${scenePath}.title`, scene.title);
+    validateRequiredText(issues, `${scenePath}.description`, scene.description);
+    validateSettingType(issues, `${scenePath}.setting_type`, scene.setting_type);
+    validateOptionalReference(issues, `${scenePath}.location_id`, scene.location_id, locationIds, "location");
+
+    if (scene.shots.length === 0) {
+      addIssue(issues, `${scenePath}.shots`, "Add at least one shot to this scene.");
+    }
+    scene.shots.forEach((shot, shotIndex) => {
+      const shotPath = `${scenePath}.shots.${shotIndex}`;
+      shotIdentities.push({ item: shot, path: shotPath });
+      validateRequiredText(issues, `${shotPath}.description`, shot.description);
+      validateRequiredText(issues, `${shotPath}.visual_prompt`, shot.visual_prompt);
+      if (!isPositiveInteger(shot.duration_seconds)) {
+        addIssue(issues, `${shotPath}.duration_seconds`, "Enter a positive whole-number duration.");
+      }
+      validateReferenceList(issues, `${shotPath}.product_ids`, shot.product_ids ?? [], undefined, "product");
+      validateReferenceList(issues, `${shotPath}.character_ids`, shot.character_ids ?? [], characterIds, "character");
+      validateReferenceList(issues, `${shotPath}.scene_ids`, shot.scene_ids ?? [], sceneIds, "scene");
+
+      (shot.dialogue ?? []).forEach((dialogue, dialogueIndex) => {
+        const dialoguePath = `${shotPath}.dialogue.${dialogueIndex}`;
+        dialogueIdentities.push({ item: dialogue, path: dialoguePath });
+        validateRequiredReference(issues, `${dialoguePath}.character_id`, dialogue.character_id, characterIds, "character");
+        validateRequiredText(issues, `${dialoguePath}.text`, dialogue.text);
+      });
+    });
+  });
+
+  collectNestedEntityIds(issues, shotIdentities, "shot", "shot_id");
+  collectNestedEntityIds(issues, dialogueIdentities, "dialogue", "dialogue_id");
+  return issues;
+}
+
+function assertEditableOrderCanPreserveCanonicalOrder(script: V2ScriptPlan): void {
+  const canonicalShotIds = script.shots.map((shot) => shot.shot_id);
+  const flattenedShotIds = script.scenes.flatMap((scene) => script.shots
+    .filter((shot) => shot.scene_id === scene.scene_id)
+    .map((shot) => shot.shot_id));
+
+  if (canonicalShotIds.length !== flattenedShotIds.length || canonicalShotIds.some((shotId, index) => shotId !== flattenedShotIds[index])) {
+    throw new CanonicalScreenplayOrderError();
+  }
+}
+
+function toEditableCharacter(character: V2ScriptPlan["characters"][number]): V2EditableScriptCharacter {
+  return {
+    character_id: character.character_id,
+    display_name: character.display_name,
+    description: character.description,
+    role: character.role,
+    visual_notes: character.visual_notes,
+    gender: character.gender,
+  };
+}
+
+function toEditableLocation(location: V2ScriptPlan["locations"][number]): V2EditableScriptLocation {
+  return {
+    location_id: location.location_id,
+    display_name: location.display_name,
+    description: location.description,
+    visual_notes: location.visual_notes,
+    location_type: location.location_type,
+    time_of_day: location.time_of_day,
+    setting_type: location.setting_type,
+  };
+}
+
+function createClientKey(namespace: string): string {
+  nextClientKey += 1;
+  return `${namespace}-client-${nextClientKey}`;
+}
+
+function isArrayIndex(value: number, length: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value < length;
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function validateRequiredText(issues: EditableScriptValidationIssue[], path: string, value: string | null | undefined): void {
+  if (!value?.trim()) {
+    addIssue(issues, path, "This field is required.");
+  }
+}
+
+function validateSettingType(
+  issues: EditableScriptValidationIssue[],
+  path: string,
+  value: "interior" | "exterior" | null | undefined,
+): void {
+  if (value != null && value !== "interior" && value !== "exterior") {
+    addIssue(issues, path, "Choose interior or exterior.");
+  }
+}
+
+function collectEntityIds<
+  T extends { client_key?: string | null },
+  IdField extends keyof T,
+>(
+  issues: EditableScriptValidationIssue[],
+  items: T[],
+  namespace: string,
+  idField: IdField,
+  collectionPath: string,
+): Set<string> {
+  const identities = new Set<string>();
+  items.forEach((item, index) => {
+    const identity = validateEntityIdentity(issues, `${collectionPath}.${index}`, namespace, item[idField], item.client_key);
+    if (identity) {
+      if (identities.has(identity)) {
+        addIssue(issues, `${collectionPath}.${index}.${String(idField)}`, `Duplicate ${namespace} identity.`);
+      }
+      identities.add(identity);
+    }
+  });
+  return identities;
+}
+
+function collectNestedEntityIds<
+  T extends { client_key?: string | null },
+  IdField extends keyof T,
+>(
+  issues: EditableScriptValidationIssue[],
+  items: Array<{ item: T; path: string }>,
+  namespace: string,
+  idField: IdField,
+): void {
+  const identities = new Set<string>();
+  items.forEach(({ item, path }) => {
+    const identity = validateEntityIdentity(issues, path, namespace, item[idField], item.client_key);
+    if (identity) {
+      if (identities.has(identity)) {
+        addIssue(issues, `${path}.${String(idField)}`, `Duplicate ${namespace} identity.`);
+      }
+      identities.add(identity);
+    }
+  });
+}
+
+function validateEntityIdentity(
+  issues: EditableScriptValidationIssue[],
+  path: string,
+  namespace: string,
+  canonicalId: unknown,
+  clientKey: unknown,
+): string | null {
+  const canonical = normalizeId(canonicalId);
+  const client = normalizeId(clientKey);
+  if (canonical && client) {
+    addIssue(issues, `${path}.client_key`, `A retained ${namespace} cannot also have a client key.`);
+    return canonical;
+  }
+  if (!canonical && !client) {
+    addIssue(issues, `${path}.${namespace}_id`, `Provide a canonical ${namespace} ID or client key.`);
+    return null;
+  }
+  return canonical ?? client;
+}
+
+function validateReferenceList(
+  issues: EditableScriptValidationIssue[],
+  path: string,
+  values: string[],
+  availableIds: Set<string> | undefined,
+  label: string,
+): void {
+  const seen = new Set<string>();
+  values.forEach((value, index) => {
+    const referencePath = `${path}.${index}`;
+    const normalized = normalizeId(value);
+    if (!normalized) {
+      addIssue(issues, referencePath, `Choose a ${label} reference.`);
+      return;
+    }
+    if (seen.has(normalized)) {
+      addIssue(issues, referencePath, `Duplicate ${label} reference.`);
+      return;
+    }
+    seen.add(normalized);
+    if (availableIds && !availableIds.has(normalized)) {
+      addIssue(issues, referencePath, `Select an active ${label}.`);
+    }
+  });
+}
+
+function validateOptionalReference(
+  issues: EditableScriptValidationIssue[],
+  path: string,
+  value: string | null | undefined,
+  availableIds: Set<string>,
+  label: string,
+): void {
+  if (value == null) {
+    return;
+  }
+  validateRequiredReference(issues, path, value, availableIds, label);
+}
+
+function validateRequiredReference(
+  issues: EditableScriptValidationIssue[],
+  path: string,
+  value: string,
+  availableIds: Set<string>,
+  label: string,
+): void {
+  const normalized = normalizeId(value);
+  if (!normalized || !availableIds.has(normalized)) {
+    addIssue(issues, path, `Select an active ${label}.`);
+  }
+}
+
+function normalizeId(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function addIssue(issues: EditableScriptValidationIssue[], path: string, message: string): void {
+  issues.push({ path, message });
+}

--- a/apps/web/src/features/workflow/v2/screenplay/screenplayReducer.ts
+++ b/apps/web/src/features/workflow/v2/screenplay/screenplayReducer.ts
@@ -1,0 +1,393 @@
+import type {
+  V2EditableScriptDocument,
+  V2ScriptPlan,
+  V2ScriptStructuralDiff,
+  V2ScriptVersionSummary,
+} from "../../../../types-v2.ts";
+import {
+  scriptToEditableDocument,
+  type EditableScriptValidationIssue,
+} from "./screenplayModel.ts";
+
+export type ScreenplayRequestError = {
+  operation: "open" | "confirm" | "select" | "refresh_selected" | "refresh_history";
+  message: string;
+  status?: number;
+  code?: string;
+  details?: Record<string, unknown>;
+};
+
+export type ScreenplayConflict = {
+  status: "unresolved" | "reviewing_local";
+  failedBaseScriptVersionId: string;
+  localDraft: V2EditableScriptDocument;
+  message: string;
+  serverScriptVersionId: string | null;
+};
+
+export type ScreenplayCloseState = "idle" | "confirmation_required" | "ready_to_close" | "closed";
+
+export type V2ScreenplayState = {
+  workflowId: string | null;
+  isOpen: boolean;
+  isLoading: boolean;
+  isSaving: boolean;
+  isSelecting: boolean;
+  selectedScript: V2ScriptPlan | null;
+  selectedScriptVersionId: string | null;
+  versions: ReadonlyArray<V2ScriptVersionSummary>;
+  draft: V2EditableScriptDocument | null;
+  draftBaseScriptVersionId: string | null;
+  dirty: boolean;
+  validationErrors: ReadonlyArray<EditableScriptValidationIssue>;
+  requestError: ScreenplayRequestError | null;
+  conflict: ScreenplayConflict | null;
+  lastStructuralDiff: V2ScriptStructuralDiff | null;
+  closeState: ScreenplayCloseState;
+  generation: number;
+  selectedRequestToken: number | null;
+  historyRequestToken: number | null;
+  saveRequestToken: number | null;
+  selectRequestToken: number | null;
+};
+
+export type ScreenplayReducerAction =
+  | { type: "OPEN_STARTED"; workflowId: string; generation: number; requestToken: number }
+  | { type: "OPEN_SUCCEEDED"; workflowId: string; generation: number; requestToken: number; script: V2ScriptPlan; selectedScriptVersionId: string; versions: V2ScriptVersionSummary[] }
+  | { type: "OPEN_FAILED"; workflowId: string; generation: number; requestToken: number; error: ScreenplayRequestError }
+  | { type: "DRAFT_UPDATED"; document: V2EditableScriptDocument }
+  | { type: "VALIDATION_FAILED"; validationErrors: EditableScriptValidationIssue[] }
+  | { type: "CONFIRM_STARTED"; workflowId: string; generation: number; requestToken: number }
+  | { type: "CONFIRM_SUCCEEDED"; workflowId: string; generation: number; requestToken: number; script: V2ScriptPlan; selectedScriptVersionId: string; structuralDiff: V2ScriptStructuralDiff }
+  | { type: "CONFIRM_FAILED"; workflowId: string; generation: number; requestToken: number; error: ScreenplayRequestError }
+  | { type: "CONFLICT_DETECTED"; workflowId: string; generation: number; requestToken: number; failedBaseScriptVersionId: string; localDraft: V2EditableScriptDocument; message: string }
+  | { type: "SELECT_STARTED"; workflowId: string; generation: number; requestToken: number }
+  | { type: "SELECT_SUCCEEDED"; workflowId: string; generation: number; requestToken: number; script: V2ScriptPlan; selectedScriptVersionId: string; structuralDiff: V2ScriptStructuralDiff }
+  | { type: "SELECT_FAILED"; workflowId: string; generation: number; requestToken: number; error: ScreenplayRequestError }
+  | { type: "SELECTED_REFRESH_STARTED"; workflowId: string; generation: number; requestToken: number }
+  | { type: "SELECTED_BUNDLE_SUCCEEDED"; workflowId: string; generation: number; requestToken: number; script: V2ScriptPlan; selectedScriptVersionId: string; versions: V2ScriptVersionSummary[] }
+  | { type: "SELECTED_BUNDLE_FAILED"; workflowId: string; generation: number; requestToken: number; error: ScreenplayRequestError }
+  | { type: "HISTORY_REFRESH_STARTED"; workflowId: string; generation: number; requestToken: number }
+  | { type: "HISTORY_REFRESH_SUCCEEDED"; workflowId: string; generation: number; requestToken: number; selectedScriptVersionId: string; versions: V2ScriptVersionSummary[] }
+  | { type: "HISTORY_REFRESH_FAILED"; workflowId: string; generation: number; requestToken: number; error: ScreenplayRequestError }
+  | { type: "KEEP_REVIEWING_LOCAL_DRAFT" }
+  | { type: "DISCARD_LOCAL_DRAFT_AND_RELOAD_LATEST" }
+  | { type: "CLOSE_REQUESTED" }
+  | { type: "CLOSE_CANCELLED" }
+  | { type: "CLOSE_CONFIRMED"; generation: number };
+
+export function createV2ScreenplayState(): V2ScreenplayState {
+  return {
+    workflowId: null,
+    isOpen: false,
+    isLoading: false,
+    isSaving: false,
+    isSelecting: false,
+    selectedScript: null,
+    selectedScriptVersionId: null,
+    versions: freezeVersions([]),
+    draft: null,
+    draftBaseScriptVersionId: null,
+    dirty: false,
+    validationErrors: [],
+    requestError: null,
+    conflict: null,
+    lastStructuralDiff: null,
+    closeState: "idle",
+    generation: 0,
+    selectedRequestToken: null,
+    historyRequestToken: null,
+    saveRequestToken: null,
+    selectRequestToken: null,
+  };
+}
+
+export function screenplayReducer(state: V2ScreenplayState, action: ScreenplayReducerAction): V2ScreenplayState {
+  switch (action.type) {
+    case "OPEN_STARTED":
+      return {
+        ...createV2ScreenplayState(),
+        workflowId: action.workflowId,
+        isOpen: true,
+        isLoading: true,
+        generation: action.generation,
+        selectedRequestToken: action.requestToken,
+        historyRequestToken: action.requestToken,
+      };
+    case "OPEN_SUCCEEDED":
+      if (!matchesOpenRequest(state, action)) return state;
+      return adoptServerScript({
+        ...state,
+        isLoading: false,
+        selectedRequestToken: null,
+        historyRequestToken: null,
+        requestError: null,
+        versions: freezeVersions(action.versions),
+      }, action.script, action.selectedScriptVersionId, true);
+    case "OPEN_FAILED":
+      if (!matchesOpenRequest(state, action)) return state;
+      return {
+        ...state,
+        isLoading: false,
+        selectedRequestToken: null,
+        historyRequestToken: null,
+        requestError: action.error,
+      };
+    case "DRAFT_UPDATED":
+      if (!state.isOpen || state.isSaving || state.isSelecting) return state;
+      return {
+        ...state,
+        draft: cloneDocument(action.document),
+        dirty: true,
+        validationErrors: [],
+        requestError: null,
+        closeState: "idle",
+      };
+    case "VALIDATION_FAILED":
+      return {
+        ...state,
+        validationErrors: action.validationErrors.map((issue) => ({ ...issue })),
+        requestError: null,
+      };
+    case "CONFIRM_STARTED":
+      if (!matchesWorkflowAndGeneration(state, action)) return state;
+      return {
+        ...state,
+        isLoading: false,
+        isSaving: true,
+        isSelecting: false,
+        selectedRequestToken: action.requestToken,
+        historyRequestToken: null,
+        saveRequestToken: action.requestToken,
+        selectRequestToken: null,
+        requestError: null,
+        validationErrors: [],
+      };
+    case "CONFIRM_SUCCEEDED":
+      if (!matchesSaveRequest(state, action)) return state;
+      return adoptServerScript({
+        ...state,
+        isSaving: false,
+        saveRequestToken: null,
+        dirty: false,
+        validationErrors: [],
+        requestError: null,
+        conflict: null,
+        lastStructuralDiff: action.structuralDiff,
+      }, action.script, action.selectedScriptVersionId, true);
+    case "CONFIRM_FAILED":
+      if (!matchesSaveRequest(state, action)) return state;
+      return { ...state, isSaving: false, saveRequestToken: null, requestError: action.error };
+    case "CONFLICT_DETECTED":
+      if (!matchesSaveRequest(state, action)) return state;
+      return {
+        ...state,
+        isSaving: false,
+        saveRequestToken: null,
+        conflict: {
+          status: "unresolved",
+          failedBaseScriptVersionId: action.failedBaseScriptVersionId,
+          localDraft: cloneDocument(action.localDraft),
+          message: action.message,
+          serverScriptVersionId: state.selectedScriptVersionId,
+        },
+      };
+    case "SELECT_STARTED":
+      if (!matchesWorkflowAndGeneration(state, action)) return state;
+      return {
+        ...state,
+        isLoading: false,
+        isSaving: false,
+        isSelecting: true,
+        selectedRequestToken: action.requestToken,
+        historyRequestToken: null,
+        saveRequestToken: null,
+        selectRequestToken: action.requestToken,
+        requestError: null,
+      };
+    case "SELECT_SUCCEEDED":
+      if (!matchesSelectRequest(state, action)) return state;
+      return adoptServerScript({
+        ...state,
+        isSelecting: false,
+        selectRequestToken: null,
+        dirty: false,
+        validationErrors: [],
+        requestError: null,
+        conflict: null,
+        lastStructuralDiff: action.structuralDiff,
+      }, action.script, action.selectedScriptVersionId, true);
+    case "SELECT_FAILED":
+      if (!matchesSelectRequest(state, action)) return state;
+      return { ...state, isSelecting: false, selectRequestToken: null, requestError: action.error };
+    case "SELECTED_REFRESH_STARTED":
+      if (!matchesWorkflowAndGeneration(state, action)) return state;
+      return {
+        ...state,
+        isLoading: true,
+        isSaving: false,
+        isSelecting: false,
+        selectedRequestToken: action.requestToken,
+        historyRequestToken: action.requestToken,
+        saveRequestToken: null,
+        selectRequestToken: null,
+        requestError: null,
+      };
+    case "SELECTED_BUNDLE_SUCCEEDED":
+      if (!matchesSelectedBundleRequest(state, action)) return state;
+      return adoptServerScript({
+        ...state,
+        isLoading: false,
+        selectedRequestToken: null,
+        historyRequestToken: null,
+        requestError: null,
+        versions: freezeVersions(action.versions),
+      }, action.script, action.selectedScriptVersionId, !state.dirty && !state.conflict);
+    case "SELECTED_BUNDLE_FAILED":
+      if (!matchesSelectedBundleRequest(state, action)) return state;
+      return { ...state, isLoading: false, selectedRequestToken: null, historyRequestToken: null, requestError: action.error };
+    case "HISTORY_REFRESH_STARTED":
+      if (!matchesWorkflowAndGeneration(state, action)) return state;
+      return { ...state, isLoading: true, historyRequestToken: action.requestToken, requestError: null };
+    case "HISTORY_REFRESH_SUCCEEDED":
+      if (!matchesHistoryRefreshRequest(state, action)) return state;
+      if (state.selectedScriptVersionId !== action.selectedScriptVersionId) {
+        return {
+          ...state,
+          isLoading: false,
+          historyRequestToken: null,
+          requestError: {
+            operation: "refresh_history",
+            message: "Screenplay history no longer matches the selected screenplay version.",
+            code: "screenplay_selection_history_mismatch",
+          },
+        };
+      }
+      return { ...state, isLoading: false, historyRequestToken: null, requestError: null, versions: freezeVersions(action.versions) };
+    case "HISTORY_REFRESH_FAILED":
+      if (!matchesHistoryRefreshRequest(state, action)) return state;
+      return { ...state, isLoading: false, historyRequestToken: null, requestError: action.error };
+    case "KEEP_REVIEWING_LOCAL_DRAFT":
+      if (!state.conflict) return state;
+      return { ...state, conflict: { ...state.conflict, status: "reviewing_local" } };
+    case "DISCARD_LOCAL_DRAFT_AND_RELOAD_LATEST":
+      if (!state.conflict || !state.selectedScript) return state;
+      return {
+        ...state,
+        draft: scriptToEditableDocument(state.selectedScript),
+        draftBaseScriptVersionId: state.selectedScriptVersionId,
+        dirty: false,
+        validationErrors: [],
+        requestError: null,
+        conflict: null,
+        closeState: "idle",
+      };
+    case "CLOSE_REQUESTED":
+      if (!state.isOpen) return state;
+      return state.dirty
+        ? { ...state, closeState: "confirmation_required" }
+        : { ...state, closeState: "ready_to_close" };
+    case "CLOSE_CANCELLED":
+      return state.closeState === "confirmation_required" ? { ...state, closeState: "idle" } : state;
+    case "CLOSE_CONFIRMED":
+      if (!state.isOpen) return state;
+      return {
+        ...state,
+        isOpen: false,
+        isLoading: false,
+        isSaving: false,
+        isSelecting: false,
+        closeState: "closed",
+        draft: state.selectedScript ? scriptToEditableDocument(state.selectedScript) : state.draft,
+        draftBaseScriptVersionId: state.selectedScriptVersionId,
+        dirty: false,
+        validationErrors: [],
+        conflict: null,
+        generation: action.generation,
+        selectedRequestToken: null,
+        historyRequestToken: null,
+        saveRequestToken: null,
+        selectRequestToken: null,
+      };
+  }
+}
+
+function adoptServerScript(
+  state: V2ScreenplayState,
+  script: V2ScriptPlan,
+  selectedScriptVersionId: string,
+  replaceDraft: boolean,
+): V2ScreenplayState {
+  const conflict = state.conflict
+    ? { ...state.conflict, serverScriptVersionId: selectedScriptVersionId }
+    : null;
+  return {
+    ...state,
+    selectedScript: script,
+    selectedScriptVersionId,
+    draft: replaceDraft ? scriptToEditableDocument(script) : state.draft,
+    draftBaseScriptVersionId: replaceDraft ? selectedScriptVersionId : state.draftBaseScriptVersionId,
+    conflict,
+  };
+}
+
+function freezeVersions(versions: V2ScriptVersionSummary[]): ReadonlyArray<V2ScriptVersionSummary> {
+  return Object.freeze(versions.map((version) => Object.freeze({
+    ...version,
+    structural_diff_summary: Object.freeze({ ...version.structural_diff_summary }),
+  })));
+}
+
+function cloneDocument(document: V2EditableScriptDocument): V2EditableScriptDocument {
+  return structuredClone(document);
+}
+
+function matchesWorkflowAndGeneration(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number },
+): boolean {
+  return state.workflowId === action.workflowId && state.generation === action.generation;
+}
+
+function matchesOpenRequest(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number; requestToken: number },
+): boolean {
+  return matchesWorkflowAndGeneration(state, action)
+    && state.selectedRequestToken === action.requestToken
+    && state.historyRequestToken === action.requestToken;
+}
+
+function matchesSaveRequest(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number; requestToken: number },
+): boolean {
+  return matchesWorkflowAndGeneration(state, action)
+    && state.selectedRequestToken === action.requestToken
+    && state.saveRequestToken === action.requestToken;
+}
+
+function matchesSelectRequest(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number; requestToken: number },
+): boolean {
+  return matchesWorkflowAndGeneration(state, action)
+    && state.selectedRequestToken === action.requestToken
+    && state.selectRequestToken === action.requestToken;
+}
+
+function matchesSelectedBundleRequest(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number; requestToken: number },
+): boolean {
+  return matchesWorkflowAndGeneration(state, action)
+    && state.selectedRequestToken === action.requestToken
+    && state.historyRequestToken === action.requestToken;
+}
+
+function matchesHistoryRefreshRequest(
+  state: V2ScreenplayState,
+  action: { workflowId: string; generation: number; requestToken: number },
+): boolean {
+  return matchesWorkflowAndGeneration(state, action) && state.historyRequestToken === action.requestToken;
+}

--- a/apps/web/src/features/workflow/v2/screenplay/screenplayUiHelpers.ts
+++ b/apps/web/src/features/workflow/v2/screenplay/screenplayUiHelpers.ts
@@ -1,0 +1,82 @@
+export type ScreenplayProductOption = {
+  id: string;
+  label?: string;
+};
+
+export type ScreenplayVersionTarget = {
+  script_version_id: string;
+  script_title: string;
+};
+
+export type ProductBeatRow = {
+  key: string;
+  value: string;
+};
+
+export function mergeProductOptions(
+  supplied: readonly ScreenplayProductOption[],
+  referencedIds: readonly string[],
+): ScreenplayProductOption[] {
+  const merged = new Map<string, ScreenplayProductOption>();
+  supplied.forEach((option) => {
+    if (option.id.trim()) merged.set(option.id, { id: option.id, label: option.label || option.id });
+  });
+  referencedIds.forEach((id) => {
+    if (id.trim() && !merged.has(id)) merged.set(id, { id, label: id });
+  });
+  return [...merged.values()];
+}
+
+export function selectionGate(dirty: boolean, target: ScreenplayVersionTarget): { action: "select" | "confirm_discard"; target: ScreenplayVersionTarget } {
+  return { action: dirty ? "confirm_discard" : "select", target };
+}
+
+export function nextFocusableIndex(index: number, count: number, backwards: boolean): number {
+  if (count <= 0) return -1;
+  return (index + (backwards ? -1 : 1) + count) % count;
+}
+
+export function nextTabIndex(key: string, index: number, count: number): number | null {
+  if (key === "ArrowLeft") return nextFocusableIndex(index, count, true);
+  if (key === "ArrowRight") return nextFocusableIndex(index, count, false);
+  if (key === "Home") return 0;
+  if (key === "End") return Math.max(0, count - 1);
+  return null;
+}
+
+export function parsePositiveDuration(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function draftDurationValue(value: string, _fallback: number): number {
+  if (!value.trim()) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function versionSelectionFocusTarget({ failed, triggerEnabled }: { failed: boolean; triggerEnabled: boolean }): "trigger" | "stable" {
+  return failed && triggerEnabled ? "trigger" : "stable";
+}
+
+export function createProductBeatRows(values: readonly string[], nextKey: () => string): ProductBeatRow[] {
+  return values.map((value) => ({ key: nextKey(), value }));
+}
+
+export function reconcileProductBeatRows(
+  current: readonly ProductBeatRow[],
+  nextValues: readonly string[],
+  nextKey: () => string,
+): ProductBeatRow[] {
+  const unused = [...current];
+  return nextValues.map((value) => {
+    const index = unused.findIndex((row) => row.value === value);
+    if (index < 0) return { key: nextKey(), value };
+    const [row] = unused.splice(index, 1);
+    return row;
+  });
+}
+
+export function summarizeValidationIssues<T extends { path: string; message: string }>(issues: readonly T[]): T[] {
+  return issues.map((issue) => ({ ...issue }));
+}

--- a/apps/web/src/features/workflow/v2/screenplay/useV2ScreenplayController.ts
+++ b/apps/web/src/features/workflow/v2/screenplay/useV2ScreenplayController.ts
@@ -1,0 +1,709 @@
+import { useCallback, useReducer, useRef } from "react";
+import { V2ApiError, v2Api } from "../../../../api/v2Client.ts";
+import type {
+  V2EditableScriptDocument,
+  V2LinkedContextSummary,
+  V2ScriptConfirmResponse,
+  V2ScriptReadResponse,
+  V2ScriptSelectVersionResponse,
+  V2ScriptVersionListResponse,
+  WorkflowRuntimeEventV2,
+} from "../../../../types-v2.ts";
+import { isV2SynchronizationEvent } from "../../../../workflow-v2/runtime.ts";
+import { validateEditableScript } from "./screenplayModel.ts";
+import {
+  createV2LocalSynchronizationRefreshPlan,
+  createV2SynchronizationRefreshPlan,
+  type V2SynchronizationRefreshPlan,
+} from "../../runtime/v2RuntimeEventModel.ts";
+import {
+  createV2SynchronizationRefreshCoordinator,
+  type V2SynchronizationRefreshCoordinator,
+  type V2SynchronizationRefreshScope,
+} from "../../runtime/v2SynchronizationRefreshCoordinator.ts";
+import {
+  createV2ScreenplayState,
+  screenplayReducer,
+  type ScreenplayRequestError,
+  type ScreenplayReducerAction,
+  type V2ScreenplayState,
+} from "./screenplayReducer.ts";
+
+export type ScreenplayDraftUpdater = (draft: V2EditableScriptDocument) => V2EditableScriptDocument;
+
+export type V2ScreenplayApi = Pick<typeof v2Api, "script" | "confirmScript" | "scriptVersions" | "selectScriptVersion">;
+
+export type V2ScreenplayControllerCallbacks = {
+  refreshWorkflow?: (workflowId: string, linkedContext: V2LinkedContextSummary) => Promise<unknown> | unknown;
+  refreshRuntime?: (workflowId: string, linkedContext: V2LinkedContextSummary) => Promise<unknown> | unknown;
+  refreshSynchronizationWorkflow?: (
+    workflowId: string,
+    scopes: ReadonlySet<V2SynchronizationRefreshScope>,
+  ) => Promise<unknown> | unknown;
+};
+
+export type V2ScreenplayControllerRuntimeOptions = V2ScreenplayControllerCallbacks & {
+  api: V2ScreenplayApi;
+  getState: () => V2ScreenplayState;
+  dispatch: (action: ScreenplayReducerAction) => void;
+  synchronizationCoordinator?: V2SynchronizationRefreshCoordinator;
+};
+
+export type UseV2ScreenplayControllerOptions = V2ScreenplayControllerCallbacks & {
+  api?: V2ScreenplayApi;
+  synchronizationCoordinator?: V2SynchronizationRefreshCoordinator;
+};
+
+export type V2ScreenplayController = {
+  state: V2ScreenplayState;
+  open: (workflowId: string) => Promise<void>;
+  close: () => "closed" | "confirmation_required";
+  cancelClose: () => void;
+  discardDraftAndClose: () => void;
+  updateDraft: (update: V2EditableScriptDocument | ScreenplayDraftUpdater) => void;
+  confirm: () => Promise<void>;
+  selectVersion: (versionId: string) => Promise<void>;
+  refreshSelected: () => Promise<void>;
+  refreshHistory: () => Promise<void>;
+  keepReviewingLocalDraft: () => void;
+  discardLocalDraftAndReloadLatest: () => void;
+  handleRuntimeEvents: (events: WorkflowRuntimeEventV2[]) => Promise<void>;
+};
+
+export type V2ScreenplayControllerRuntime = Omit<V2ScreenplayController, "state">;
+
+export function createV2ScreenplayControllerRuntime({
+  api,
+  getState,
+  dispatch,
+  refreshWorkflow,
+  refreshRuntime,
+  refreshSynchronizationWorkflow,
+  synchronizationCoordinator = createV2SynchronizationRefreshCoordinator(),
+}: V2ScreenplayControllerRuntimeOptions): V2ScreenplayControllerRuntime {
+  let sessionGeneration = 0;
+  let requestToken = 0;
+  let queuedHistoryRefresh: {
+    workflowId: string;
+    generation: number;
+    ownerRequestToken: number;
+    promise: Promise<void>;
+    resolve: () => void;
+  } | null = null;
+  let queuedSynchronizationPlans: Array<{
+    workflowId: string;
+    generation: number;
+    plan: V2SynchronizationRefreshPlan;
+  }> = [];
+
+  const nextRequestToken = () => {
+    requestToken += 1;
+    return requestToken;
+  };
+
+  const isSessionActive = (workflowId: string, generation: number): boolean => {
+    const state = getState();
+    return state.isOpen && state.workflowId === workflowId && state.generation === generation;
+  };
+
+  const isSelectedRequestActive = (workflowId: string, generation: number, request: number): boolean => {
+    return isSessionActive(workflowId, generation) && getState().selectedRequestToken === request;
+  };
+
+  const isHistoryRequestActive = (workflowId: string, generation: number, request: number): boolean => {
+    return isSessionActive(workflowId, generation) && getState().historyRequestToken === request;
+  };
+
+  const isSelectedBundleRequestActive = (workflowId: string, generation: number, request: number): boolean => {
+    return isSelectedRequestActive(workflowId, generation, request)
+      && getState().historyRequestToken === request;
+  };
+
+  const isOpenRequestActive = (workflowId: string, generation: number, request: number): boolean => {
+    return isSelectedBundleRequestActive(workflowId, generation, request);
+  };
+
+  const isInitialOpenPending = (state: V2ScreenplayState): boolean => {
+    return state.selectedScriptVersionId === null
+      && state.draft === null
+      && state.selectedRequestToken !== null
+      && state.historyRequestToken === state.selectedRequestToken;
+  };
+
+  const hasActiveLocalSelectionOperation = (state: V2ScreenplayState): boolean =>
+    (state.isSaving
+      && state.saveRequestToken !== null
+      && state.saveRequestToken === state.selectedRequestToken)
+    || (state.isSelecting
+      && state.selectRequestToken !== null
+      && state.selectRequestToken === state.selectedRequestToken);
+
+  const clearQueuedSynchronizationPlans = (): void => {
+    queuedSynchronizationPlans = [];
+  };
+
+  const queueSynchronizationPlan = (
+    workflowId: string,
+    generation: number,
+    plan: V2SynchronizationRefreshPlan,
+  ): void => {
+    let mergedPlan = plan;
+    const aliases = synchronizationPlanAliases(plan);
+    for (let index = queuedSynchronizationPlans.length - 1; index >= 0; index -= 1) {
+      const queued = queuedSynchronizationPlans[index];
+      if (queued.workflowId !== workflowId || queued.generation !== generation) continue;
+      const queuedAliases = synchronizationPlanAliases(queued.plan);
+      const shouldMerge = aliases.size === 0
+        ? queuedAliases.size === 0
+        : setsOverlap(aliases, queuedAliases);
+      if (!shouldMerge) continue;
+      mergedPlan = mergeSynchronizationRefreshPlans(queued.plan, mergedPlan);
+      synchronizationPlanAliases(mergedPlan).forEach((alias) => aliases.add(alias));
+      queuedSynchronizationPlans.splice(index, 1);
+    }
+    queuedSynchronizationPlans.push({ workflowId, generation, plan: mergedPlan });
+    if (queuedSynchronizationPlans.length > 32) queuedSynchronizationPlans.splice(0, queuedSynchronizationPlans.length - 32);
+  };
+
+  const clearQueuedHistoryRefresh = (criteria?: { workflowId: string; generation: number; ownerRequestToken?: number }): void => {
+    const queued = queuedHistoryRefresh;
+    if (!queued || (criteria && (
+      queued.workflowId !== criteria.workflowId
+      || queued.generation !== criteria.generation
+      || (criteria.ownerRequestToken !== undefined && queued.ownerRequestToken !== criteria.ownerRequestToken)
+    ))) return;
+    queuedHistoryRefresh = null;
+    queued.resolve();
+  };
+
+  const handoffQueuedHistoryRefresh = (workflowId: string, generation: number, ownerRequestToken: number): void => {
+    if (queuedHistoryRefresh?.workflowId !== workflowId || queuedHistoryRefresh.generation !== generation) return;
+    queuedHistoryRefresh.ownerRequestToken = ownerRequestToken;
+  };
+
+  const queueHistoryRefresh = (workflowId: string, generation: number): Promise<void> => {
+    if (queuedHistoryRefresh?.workflowId === workflowId && queuedHistoryRefresh.generation === generation) {
+      return queuedHistoryRefresh.promise;
+    }
+    clearQueuedHistoryRefresh();
+    let resolve = () => {};
+    const promise = new Promise<void>((nextResolve) => { resolve = nextResolve; });
+    queuedHistoryRefresh = {
+      workflowId,
+      generation,
+      ownerRequestToken: getState().selectedRequestToken ?? -1,
+      promise,
+      resolve,
+    };
+    return promise;
+  };
+
+  const flushQueuedHistoryRefresh = async (workflowId: string, generation: number, ownerRequestToken: number): Promise<void> => {
+    const queued = queuedHistoryRefresh;
+    if (!queued || queued.workflowId !== workflowId || queued.generation !== generation || queued.ownerRequestToken !== ownerRequestToken) return;
+    queuedHistoryRefresh = null;
+    try {
+      if (isSessionActive(workflowId, generation)) await refreshHistory();
+    } finally {
+      queued.resolve();
+    }
+  };
+
+  const open = async (workflowId: string): Promise<void> => {
+    synchronizationCoordinator.activateWorkflow(workflowId);
+    clearQueuedHistoryRefresh();
+    clearQueuedSynchronizationPlans();
+    const generation = ++sessionGeneration;
+    const request = nextRequestToken();
+    dispatch({ type: "OPEN_STARTED", workflowId, generation, requestToken: request });
+    try {
+      const [selected, history] = await Promise.all([api.script(workflowId), api.scriptVersions(workflowId)]);
+      assertCoherentOpenResponse(workflowId, selected, history);
+      if (!isOpenRequestActive(workflowId, generation, request)) return;
+      dispatch({
+        type: "OPEN_SUCCEEDED",
+        workflowId,
+        generation,
+        requestToken: request,
+        script: selected.script,
+        selectedScriptVersionId: selected.selected_script_version_id,
+        versions: history.versions,
+      });
+      await flushQueuedHistoryRefresh(workflowId, generation, request);
+    } catch (error) {
+      if (!isOpenRequestActive(workflowId, generation, request)) {
+        clearQueuedHistoryRefresh({ workflowId, generation, ownerRequestToken: request });
+        return;
+      }
+      dispatch({ type: "OPEN_FAILED", workflowId, generation, requestToken: request, error: toRequestError("open", error) });
+      clearQueuedHistoryRefresh({ workflowId, generation, ownerRequestToken: request });
+    }
+  };
+
+  const updateDraft = (update: V2EditableScriptDocument | ScreenplayDraftUpdater): void => {
+    const state = getState();
+    if (state.isSaving || state.isSelecting) return;
+    const current = state.draft;
+    if (!current) return;
+    const workingCopy = structuredClone(current);
+    const document = typeof update === "function" ? update(workingCopy) : update;
+    dispatch({ type: "DRAFT_UPDATED", document });
+  };
+
+  const refreshSelectedWithHistory = async (
+    reusableHistory: V2ScriptVersionListResponse | null = null,
+  ): Promise<void> => {
+    const state = getState();
+    if (!state.workflowId || !state.isOpen) return;
+    const workflowId = state.workflowId;
+    const request = nextRequestToken();
+    dispatch({ type: "SELECTED_REFRESH_STARTED", workflowId, generation: state.generation, requestToken: request });
+    handoffQueuedHistoryRefresh(workflowId, state.generation, request);
+    try {
+      let selected: V2ScriptReadResponse;
+      let history: V2ScriptVersionListResponse;
+      if (reusableHistory?.workflow_id === workflowId) {
+        selected = await api.script(workflowId);
+        history = reusableHistory.selected_script_version_id === selected.selected_script_version_id
+          ? reusableHistory
+          : await api.scriptVersions(workflowId);
+      } else {
+        [selected, history] = await Promise.all([api.script(workflowId), api.scriptVersions(workflowId)]);
+      }
+      assertCoherentOpenResponse(workflowId, selected, history);
+      if (!isSelectedBundleRequestActive(workflowId, state.generation, request)) return;
+      dispatch({
+        type: "SELECTED_BUNDLE_SUCCEEDED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        script: selected.script,
+        selectedScriptVersionId: selected.selected_script_version_id,
+        versions: history.versions,
+      });
+      await flushQueuedHistoryRefresh(workflowId, state.generation, request);
+    } catch (error) {
+      if (!isSelectedBundleRequestActive(workflowId, state.generation, request)) return;
+      dispatch({
+        type: "SELECTED_BUNDLE_FAILED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        error: toRequestError("refresh_selected", error),
+      });
+      clearQueuedHistoryRefresh({ workflowId, generation: state.generation, ownerRequestToken: request });
+    }
+  };
+
+  const refreshSelected = async (): Promise<void> => {
+    await refreshSelectedWithHistory();
+  };
+
+  const refreshHistoryResponse = async (): Promise<V2ScriptVersionListResponse | null> => {
+    const state = getState();
+    if (!state.workflowId || !state.isOpen) return null;
+    if (isInitialOpenPending(state)) {
+      await queueHistoryRefresh(state.workflowId, state.generation);
+      return null;
+    }
+    const workflowId = state.workflowId;
+    const request = nextRequestToken();
+    dispatch({ type: "HISTORY_REFRESH_STARTED", workflowId, generation: state.generation, requestToken: request });
+    try {
+      const response = await api.scriptVersions(workflowId);
+      if (response.workflow_id !== workflowId) throw new Error("Screenplay history response belongs to a different workflow.");
+      if (!isHistoryRequestActive(workflowId, state.generation, request)) return null;
+      dispatch({
+        type: "HISTORY_REFRESH_SUCCEEDED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        selectedScriptVersionId: response.selected_script_version_id,
+        versions: response.versions,
+      });
+      return response;
+    } catch (error) {
+      if (!isHistoryRequestActive(workflowId, state.generation, request)) return null;
+      dispatch({
+        type: "HISTORY_REFRESH_FAILED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        error: toRequestError("refresh_history", error),
+      });
+      return null;
+    }
+  };
+
+  const refreshHistory = async (): Promise<void> => {
+    await refreshHistoryResponse();
+  };
+
+  const flushQueuedSynchronizationPlans = async (
+    workflowId: string,
+    generation: number,
+  ): Promise<{ refreshedSelected: boolean }> => {
+    const queued = queuedSynchronizationPlans.filter((entry) =>
+      entry.workflowId === workflowId && entry.generation === generation);
+    queuedSynchronizationPlans = queuedSynchronizationPlans.filter((entry) =>
+      entry.workflowId !== workflowId || entry.generation !== generation);
+    let refreshedSelected = false;
+    for (const entry of queued) {
+      refreshedSelected ||= entry.plan.refreshSelectedScreenplay;
+      if (!isSessionActive(workflowId, generation)) break;
+      await coordinateSynchronizationRefresh(workflowId, entry.plan);
+    }
+    return { refreshedSelected };
+  };
+
+  const confirm = async (): Promise<void> => {
+    const state = getState();
+    if (!state.workflowId || !state.draftBaseScriptVersionId || !state.draft || !state.isOpen) return;
+    const validationErrors = validateEditableScript(state.draft);
+    if (validationErrors.length > 0) {
+      dispatch({ type: "VALIDATION_FAILED", validationErrors });
+      return;
+    }
+
+    const workflowId = state.workflowId;
+    const baseScriptVersionId = state.draftBaseScriptVersionId;
+    const document = structuredClone(state.draft);
+    const request = nextRequestToken();
+    dispatch({ type: "CONFIRM_STARTED", workflowId, generation: state.generation, requestToken: request });
+    try {
+      const response = await api.confirmScript(workflowId, {
+        base_script_version_id: baseScriptVersionId,
+        document,
+        source_action: "script_editor_confirm",
+      });
+      assertWorkflowResponse(workflowId, response);
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      dispatch({
+        type: "CONFIRM_SUCCEEDED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        script: response.script,
+        selectedScriptVersionId: response.selected_script_version_id,
+        structuralDiff: response.structural_diff,
+      });
+      await coordinateSynchronizationRefresh(
+        workflowId,
+        createV2LocalSynchronizationRefreshPlan(response.selected_script_version_id, response.structural_diff, response.linked_context),
+        { localSelection: true, linkedContext: response.linked_context },
+      );
+      await flushQueuedSynchronizationPlans(workflowId, state.generation);
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      await notifyRuntimeRefresh(workflowId, response.linked_context, refreshRuntime);
+    } catch (error) {
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      if (isScriptVersionConflict(error)) {
+        dispatch({
+          type: "CONFLICT_DETECTED",
+          workflowId,
+          generation: state.generation,
+          requestToken: request,
+          failedBaseScriptVersionId: baseScriptVersionId,
+          localDraft: document,
+          message: error.message,
+        });
+        const queued = await flushQueuedSynchronizationPlans(workflowId, state.generation);
+        if (!queued.refreshedSelected) await refreshSelected();
+        return;
+      }
+      dispatch({
+        type: "CONFIRM_FAILED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        error: toRequestError("confirm", error),
+      });
+      await flushQueuedSynchronizationPlans(workflowId, state.generation);
+    }
+  };
+
+  const selectVersion = async (versionId: string): Promise<void> => {
+    const state = getState();
+    if (!state.workflowId || !state.selectedScriptVersionId || !state.isOpen) return;
+    const workflowId = state.workflowId;
+    const request = nextRequestToken();
+    dispatch({ type: "SELECT_STARTED", workflowId, generation: state.generation, requestToken: request });
+    try {
+      const response = await api.selectScriptVersion(workflowId, versionId, {
+        base_selected_script_version_id: state.selectedScriptVersionId,
+      });
+      assertWorkflowResponse(workflowId, response);
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      dispatch({
+        type: "SELECT_SUCCEEDED",
+        workflowId,
+        generation: state.generation,
+        requestToken: request,
+        script: response.script,
+        selectedScriptVersionId: response.selected_script_version_id,
+        structuralDiff: response.structural_diff,
+      });
+      await coordinateSynchronizationRefresh(
+        workflowId,
+        createV2LocalSynchronizationRefreshPlan(response.selected_script_version_id, response.structural_diff, response.linked_context),
+        { localSelection: true, linkedContext: response.linked_context },
+      );
+      await flushQueuedSynchronizationPlans(workflowId, state.generation);
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      await notifyRuntimeRefresh(workflowId, response.linked_context, refreshRuntime);
+    } catch (error) {
+      if (!isSelectedRequestActive(workflowId, state.generation, request)) return;
+      dispatch({ type: "SELECT_FAILED", workflowId, generation: state.generation, requestToken: request, error: toRequestError("select", error) });
+      await flushQueuedSynchronizationPlans(workflowId, state.generation);
+    }
+  };
+
+  const close = (): "closed" | "confirmation_required" => {
+    dispatch({ type: "CLOSE_REQUESTED" });
+    if (getState().closeState === "confirmation_required") return "confirmation_required";
+    finishClose();
+    return "closed";
+  };
+
+  const cancelClose = (): void => dispatch({ type: "CLOSE_CANCELLED" });
+  const finishClose = (): void => {
+    if (!getState().isOpen) return;
+    clearQueuedHistoryRefresh();
+    clearQueuedSynchronizationPlans();
+    dispatch({ type: "CLOSE_CONFIRMED", generation: ++sessionGeneration });
+  };
+  const discardDraftAndClose = (): void => finishClose();
+  const keepReviewingLocalDraft = (): void => dispatch({ type: "KEEP_REVIEWING_LOCAL_DRAFT" });
+  const discardLocalDraftAndReloadLatest = (): void => dispatch({ type: "DISCARD_LOCAL_DRAFT_AND_RELOAD_LATEST" });
+
+  const handleRuntimeEvents = async (events: WorkflowRuntimeEventV2[]): Promise<void> => {
+    const workflowId = events.find((event) => isV2SynchronizationEvent(event.event_type))?.workflow_id;
+    if (workflowId) {
+      const workflowEvents = events.filter((event) => event.workflow_id === workflowId);
+      const plan = createV2SynchronizationRefreshPlan(workflowEvents);
+      const state = getState();
+      if (
+        state.workflowId === workflowId
+        && state.isOpen
+        && hasActiveLocalSelectionOperation(state)
+      ) {
+        queueSynchronizationPlan(workflowId, state.generation, plan);
+        return;
+      }
+      await coordinateSynchronizationRefresh(workflowId, plan);
+      return;
+    }
+    const openWorkflowId = getState().workflowId;
+    if (!openWorkflowId) return;
+    const workflowEvents = events.filter((event) => event.workflow_id === openWorkflowId);
+    if (workflowEvents.some(isScreenplayRuntimeEvent)) await refreshSelected();
+  };
+
+  const coordinateSynchronizationRefresh = async (
+    workflowId: string,
+    plan: V2SynchronizationRefreshPlan,
+    options: { localSelection?: boolean; linkedContext?: V2LinkedContextSummary } = {},
+  ) => {
+    const state = getState();
+    const screenplayOpen = state.isOpen && state.workflowId === workflowId;
+    await synchronizationCoordinator.coordinate(workflowId, plan, {
+      refreshHistory: screenplayOpen ? refreshHistoryResponse : undefined,
+      refreshSelectedScreenplay: screenplayOpen
+        ? options.localSelection
+          ? async () => { await refreshHistoryResponse(); }
+          : refreshSelectedWithHistory
+        : undefined,
+      refreshWorkflow: refreshSynchronizationWorkflow || refreshWorkflow
+        ? (scopes) => refreshSynchronizationWorkflow?.(workflowId, scopes)
+          ?? refreshWorkflow?.(workflowId, options.linkedContext ?? linkedContextFromPlan(plan))
+        : undefined,
+    });
+  };
+
+  return {
+    open,
+    close,
+    cancelClose,
+    discardDraftAndClose,
+    updateDraft,
+    confirm,
+    selectVersion,
+    refreshSelected,
+    refreshHistory,
+    keepReviewingLocalDraft,
+    discardLocalDraftAndReloadLatest,
+    handleRuntimeEvents,
+  };
+}
+
+export function useV2ScreenplayController(options: UseV2ScreenplayControllerOptions = {}): V2ScreenplayController {
+  const [state, reactDispatch] = useReducer(screenplayReducer, undefined, createV2ScreenplayState);
+  const stateRef = useRef(state);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const runtimeRef = useRef<V2ScreenplayControllerRuntime | null>(null);
+
+  if (!runtimeRef.current) {
+    const api: V2ScreenplayApi = {
+      script: (...args) => (optionsRef.current.api ?? v2Api).script(...args),
+      confirmScript: (...args) => (optionsRef.current.api ?? v2Api).confirmScript(...args),
+      scriptVersions: (...args) => (optionsRef.current.api ?? v2Api).scriptVersions(...args),
+      selectScriptVersion: (...args) => (optionsRef.current.api ?? v2Api).selectScriptVersion(...args),
+    };
+    runtimeRef.current = createV2ScreenplayControllerRuntime({
+      api,
+      getState: () => stateRef.current,
+      dispatch: (action) => {
+        stateRef.current = screenplayReducer(stateRef.current, action);
+        reactDispatch(action);
+      },
+      refreshWorkflow: (...args) => optionsRef.current.refreshWorkflow?.(...args),
+      refreshRuntime: (...args) => optionsRef.current.refreshRuntime?.(...args),
+      refreshSynchronizationWorkflow: (...args) => optionsRef.current.refreshSynchronizationWorkflow?.(...args),
+      synchronizationCoordinator: options.synchronizationCoordinator,
+    });
+  }
+  stateRef.current = state;
+
+  const runtime = runtimeRef.current;
+  return {
+    state,
+    open: useCallback((workflowId) => runtime.open(workflowId), [runtime]),
+    close: useCallback(() => runtime.close(), [runtime]),
+    cancelClose: useCallback(() => runtime.cancelClose(), [runtime]),
+    discardDraftAndClose: useCallback(() => runtime.discardDraftAndClose(), [runtime]),
+    updateDraft: useCallback((update) => runtime.updateDraft(update), [runtime]),
+    confirm: useCallback(() => runtime.confirm(), [runtime]),
+    selectVersion: useCallback((versionId) => runtime.selectVersion(versionId), [runtime]),
+    refreshSelected: useCallback(() => runtime.refreshSelected(), [runtime]),
+    refreshHistory: useCallback(() => runtime.refreshHistory(), [runtime]),
+    keepReviewingLocalDraft: useCallback(() => runtime.keepReviewingLocalDraft(), [runtime]),
+    discardLocalDraftAndReloadLatest: useCallback(() => runtime.discardLocalDraftAndReloadLatest(), [runtime]),
+    handleRuntimeEvents: useCallback((events) => runtime.handleRuntimeEvents(events), [runtime]),
+  };
+}
+
+function assertCoherentOpenResponse(
+  workflowId: string,
+  selected: V2ScriptReadResponse,
+  history: V2ScriptVersionListResponse,
+): void {
+  assertWorkflowResponse(workflowId, selected);
+  if (history.workflow_id !== workflowId) throw new ScreenplaySelectionHistoryConsistencyError("Screenplay history response belongs to a different workflow.");
+  if (selected.selected_script_version_id !== history.selected_script_version_id) {
+    throw new ScreenplaySelectionHistoryConsistencyError("Screenplay selected script and version history disagree.");
+  }
+}
+
+function assertWorkflowResponse(workflowId: string, response: V2ScriptReadResponse | V2ScriptConfirmResponse | V2ScriptSelectVersionResponse): void {
+  if (response.workflow_id !== workflowId) throw new Error("Screenplay response belongs to a different workflow.");
+  if (response.selected_script_version_id !== response.script.script_version_id) {
+    throw new ScreenplayResponseVersionConsistencyError("Screenplay selected version and embedded script version disagree.");
+  }
+}
+
+class ScreenplayResponseVersionConsistencyError extends Error {
+  readonly code = "screenplay_response_version_mismatch";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ScreenplayResponseVersionConsistencyError";
+  }
+}
+
+class ScreenplaySelectionHistoryConsistencyError extends Error {
+  readonly code = "screenplay_selection_history_mismatch";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ScreenplaySelectionHistoryConsistencyError";
+  }
+}
+
+function toRequestError(operation: ScreenplayRequestError["operation"], error: unknown): ScreenplayRequestError {
+  if (error instanceof V2ApiError) {
+    return {
+      operation,
+      message: error.message,
+      status: error.status,
+      code: error.code,
+      details: { ...error.details, violations: error.violations },
+    };
+  }
+  if (error instanceof ScreenplaySelectionHistoryConsistencyError) {
+    return { operation, message: error.message, code: error.code };
+  }
+  if (error instanceof ScreenplayResponseVersionConsistencyError) {
+    return { operation, message: error.message, code: error.code };
+  }
+  return { operation, message: error instanceof Error ? error.message : "Screenplay request failed." };
+}
+
+function isScriptVersionConflict(error: unknown): error is V2ApiError {
+  return error instanceof V2ApiError && error.status === 409 && error.code === "script_version_conflict";
+}
+
+function isScreenplayRuntimeEvent(event: WorkflowRuntimeEventV2): boolean {
+  return /(^|[.:_])script([.:_]|$)|screenplay/i.test(event.event_type);
+}
+
+function synchronizationPlanAliases(plan: V2SynchronizationRefreshPlan): Set<string> {
+  return new Set([
+    ...plan.transactionIds.map((id) => `transaction:${id}`),
+    ...plan.scriptVersionIds.map((id) => `script:${id}`),
+  ]);
+}
+
+function setsOverlap(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  for (const value of left) {
+    if (right.has(value)) return true;
+  }
+  return false;
+}
+
+function mergeSynchronizationRefreshPlans(
+  left: V2SynchronizationRefreshPlan,
+  right: V2SynchronizationRefreshPlan,
+): V2SynchronizationRefreshPlan {
+  const unique = (values: string[]) => Array.from(new Set(values));
+  return {
+    isSynchronizationBatch: left.isSynchronizationBatch || right.isSynchronizationBatch,
+    refreshScreenplayHistory: left.refreshScreenplayHistory || right.refreshScreenplayHistory,
+    refreshSelectedScreenplay: left.refreshSelectedScreenplay || right.refreshSelectedScreenplay,
+    refreshWorkflow: left.refreshWorkflow || right.refreshWorkflow,
+    refreshWorkflowStructure: left.refreshWorkflowStructure || right.refreshWorkflowStructure,
+    refreshSlotPrompts: left.refreshSlotPrompts || right.refreshSlotPrompts,
+    refreshReferences: left.refreshReferences || right.refreshReferences,
+    refreshAssets: left.refreshAssets || right.refreshAssets,
+    nodeIds: unique([...left.nodeIds, ...right.nodeIds]),
+    itemIds: unique([...left.itemIds, ...right.itemIds]),
+    slotIds: unique([...left.slotIds, ...right.slotIds]),
+    transactionIds: unique([...left.transactionIds, ...right.transactionIds]),
+    scriptVersionIds: unique([...left.scriptVersionIds, ...right.scriptVersionIds]),
+  };
+}
+
+async function notifyRuntimeRefresh(
+  workflowId: string,
+  linkedContext: V2LinkedContextSummary,
+  refreshRuntime: V2ScreenplayControllerCallbacks["refreshRuntime"],
+): Promise<void> {
+  await Promise.allSettled([refreshRuntime?.(workflowId, linkedContext)]);
+}
+
+function linkedContextFromPlan(plan: V2SynchronizationRefreshPlan): V2LinkedContextSummary {
+  return {
+    updated_node_ids: plan.nodeIds,
+    updated_item_ids: plan.itemIds,
+    updated_slot_ids: plan.slotIds,
+    updated_fields: [],
+    selected_asset_versions_changed: false,
+    provider_execution_started: false,
+    refresh: [
+      ...(plan.refreshWorkflow || plan.refreshWorkflowStructure ? ["workflow"] : []),
+      ...(plan.refreshSlotPrompts ? ["slot_prompts"] : []),
+      ...(plan.refreshReferences ? ["references"] : []),
+      ...(plan.refreshAssets ? ["assets"] : []),
+    ],
+  };
+}

--- a/apps/web/src/features/workflow/v2/slots/V2SlotCard.tsx
+++ b/apps/web/src/features/workflow/v2/slots/V2SlotCard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, type MouseEvent as ReactMouseEvent } from "react";
-import type { AssetVersionV2, RuntimeRecordV2, SlotVersionsResponseV2, V2ReferenceAttachRequest, WorkflowSlotV2 } from "../../../../types-v2.ts";
-import { dedupeSlotVersionAssets, isIdOnlyAssetVersion, outdatedHintForSlot, providerAuditForSlot, safeProviderSnapshotText, usableAssetVersionUrl } from "../../../../workflow-v2/selectors.ts";
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { effectiveSlotPrompt, type AssetVersionV2, type RuntimeRecordV2, type SlotVersionsResponseV2, type V2ReferenceAttachRequest, type WorkflowSlotV2 } from "../../../../types-v2.ts";
+import { dedupeSlotVersionAssets, isIdOnlyAssetVersion, providerAuditForSlot, safeProviderSnapshotText, usableAssetVersionUrl } from "../../../../workflow-v2/selectors.ts";
 import { buildV2SlotTarget, normalizeV2SlotVersionState } from "../operations/v2SlotOperationModel.ts";
 import type { V2SlotAttachment } from "../operations/v2SlotOperationTypes.ts";
 import { V2ReferencePicker } from "../references/V2ReferencePicker.tsx";
@@ -9,6 +9,7 @@ import { V2ProviderTaskPanel } from "../provider/V2ProviderTaskPanel.tsx";
 import { useV2MediaContextMenu } from "../media/useV2MediaContextMenu.ts";
 import { V2SlotReferenceComposer } from "./V2SlotReferenceComposer.tsx";
 import { V2SlotVersionActions } from "./V2SlotVersionActions.tsx";
+import { createSlotPromptEditorState, rebaseSlotPromptEditorState, saveSlotPromptEditorState, type SlotPromptSaveResult } from "./slotPromptEditorState.ts";
 
 type V2SlotCardProps = {
   slot: WorkflowSlotV2;
@@ -20,7 +21,7 @@ type V2SlotCardProps = {
   runtimeRecord?: RuntimeRecordV2;
   onGenerate?: (slotId: string) => Promise<unknown> | unknown;
   onLoadVersions?: (slotId: string) => void;
-  onSavePrompt?: (slotId: string, prompt: string, negativePrompt?: string) => Promise<unknown> | unknown;
+  onSavePrompt?: (slotId: string, prompt: string, negativePrompt?: string) => Promise<SlotPromptSaveResult> | SlotPromptSaveResult;
   onSelectCurrentVersion?: (slotId: string, versionId: string) => void;
   onDiscardWorkingVersion?: (slotId: string) => void;
   onDeleteSelectedAsset?: (slotId: string) => void;
@@ -103,12 +104,21 @@ export function V2SlotCard({
   libraryOptions = [],
   onAttachReference,
 }: V2SlotCardProps) {
-  const [slotPrompt, setSlotPrompt] = useState(slot.slot_prompt ?? "");
-  const [negativePrompt, setNegativePrompt] = useState(slot.negative_prompt ?? "");
+  const effectivePrompt = effectiveSlotPrompt(slot);
+  const { slot_prompt, system_suggested_prompt, user_prompt, negative_prompt } = slot;
+  const serverPromptState = useMemo(
+    () => createSlotPromptEditorState({ slot_prompt, system_suggested_prompt, user_prompt, negative_prompt }),
+    [negative_prompt, slot_prompt, system_suggested_prompt, user_prompt],
+  );
+  const [promptState, setPromptState] = useState(serverPromptState);
+  const promptStateRef = useRef(promptState);
   useEffect(() => {
-    setSlotPrompt(slot.slot_prompt ?? "");
-    setNegativePrompt(slot.negative_prompt ?? "");
-  }, [slot.slot_id, slot.slot_prompt, slot.negative_prompt]);
+    setPromptState((current) => {
+      const next = rebaseSlotPromptEditorState(current, serverPromptState);
+      promptStateRef.current = next;
+      return next;
+    });
+  }, [serverPromptState]);
   const workingIsSelected = Boolean(workingVersion && selectedAsset && workingVersion.asset_id === selectedAsset.asset_id);
   const versionHistory = dedupeSlotVersionAssets(slotVersions?.versions?.length ? slotVersions.versions : historyVersions);
   const referenceAttachments = slotReferencesAsAttachments(slot, referenceAssets);
@@ -120,7 +130,6 @@ export function V2SlotCard({
     history_versions: versionHistory,
     quality_status: workingVersion?.quality_status ?? selectedAsset?.quality_status,
   });
-  const outdatedHint = outdatedHintForSlot(slot);
   const advancedPromptFields = [
     ["Dialogue prompt", slot.dialogue_prompt],
     ["Audio description prompt", slot.audio_description_prompt],
@@ -148,12 +157,40 @@ export function V2SlotCard({
   const slotWaiting = providerWaiting || runtimeStatus === "waiting" || slot.status === "waiting";
   const referenceAudit = referenceAuditForSlot(slot, runtimeRecord, workingVersion ?? selectedAsset);
   const slotLabel = SLOT_LABELS[slot.slot_type] ?? slot.slot_type.replace(/_/g, " ");
-  const promptDirty = slotPrompt !== (slot.slot_prompt ?? "") || negativePrompt !== (slot.negative_prompt ?? "");
+  const { prompt: slotPrompt, negativePrompt, dirty: promptDirty } = promptState;
+
+  function changeSlotPrompt(prompt: string) {
+    setPromptState((current) => {
+      const next = { ...current, prompt, dirty: prompt !== current.basePrompt || current.negativePrompt !== current.baseNegativePrompt };
+      promptStateRef.current = next;
+      return next;
+    });
+  }
+
+  function changeNegativePrompt(nextNegativePrompt: string) {
+    setPromptState((current) => {
+      const next = { ...current, negativePrompt: nextNegativePrompt, dirty: current.prompt !== current.basePrompt || nextNegativePrompt !== current.baseNegativePrompt };
+      promptStateRef.current = next;
+      return next;
+    });
+  }
+
+  async function savePrompt() {
+    if (!onSavePrompt) return false;
+    const submitted = promptStateRef.current;
+    const saved = await saveSlotPromptEditorState(
+      submitted,
+      () => onSavePrompt(slot.slot_id, submitted.prompt, submitted.negativePrompt),
+      () => promptStateRef.current,
+    );
+    if (!saved.saved) return false;
+    promptStateRef.current = saved.state;
+    setPromptState(saved.state);
+    return true;
+  }
 
   async function generateSlotVersion() {
-    if (promptDirty) {
-      await onSavePrompt?.(slot.slot_id, slotPrompt, negativePrompt);
-    }
+    if (promptDirty && !await savePrompt()) return;
     await onGenerate?.(slot.slot_id);
   }
 
@@ -163,13 +200,6 @@ export function V2SlotCard({
         <span>{slotLabel}</span>
         <span className="v2-slot-status">{runtimeStatus || slot.status}</span>
       </header>
-      {outdatedHint.active ? (
-        <aside className="v2-slot-outdated-hint" aria-label="Reference updated">
-          <strong>{outdatedHint.label || "Reference updated"}</strong>
-          <span>Based on an older reference</span>
-          {outdatedHint.sources.length ? <small>{outdatedHint.sources.map((source) => source.source_slot_id || source.source_asset_id || source.reason).filter(Boolean).join(" · ")}</small> : null}
-        </aside>
-      ) : null}
       {providerStatusItems.length || materializerWarnings.length ? (
         <section className="v2-provider-status" aria-label="Provider task status">
           {providerWaiting ? <strong>Generating / waiting for provider</strong> : null}
@@ -272,7 +302,7 @@ export function V2SlotCard({
           attachments={referenceAttachments}
           libraryOptions={libraryOptions}
           semanticType={slot.slot_type}
-          onPromptChange={setSlotPrompt}
+          onPromptChange={changeSlotPrompt}
           onRefreshReferences={async () => {
             onLoadVersions?.(slot.slot_id);
             await onRefreshWorkflow?.();
@@ -281,7 +311,7 @@ export function V2SlotCard({
       ) : (
         <label className="v2-slot-prompt">
           <span>Slot prompt</span>
-          <textarea value={slotPrompt} onChange={(event) => setSlotPrompt(event.target.value)} />
+          <textarea value={slotPrompt} onChange={(event) => changeSlotPrompt(event.target.value)} />
         </label>
       )}
       <V2ReferenceAuditPanel audit={referenceAudit} />
@@ -301,10 +331,10 @@ export function V2SlotCard({
       {slot.negative_prompt !== undefined ? (
         <label className="v2-slot-prompt">
           <span>Negative prompt</span>
-          <textarea value={negativePrompt} onChange={(event) => setNegativePrompt(event.target.value)} />
+          <textarea value={negativePrompt} onChange={(event) => changeNegativePrompt(event.target.value)} />
         </label>
       ) : null}
-      <button type="button" onClick={() => onSavePrompt?.(slot.slot_id, slotPrompt, negativePrompt)}>
+      <button type="button" onClick={() => void savePrompt()}>
         Save slot prompt
       </button>
       {advancedPromptFields.length || providerPromptSnapshot || agentRouteSnapshot || providerPayloadSnapshot ? (
@@ -366,6 +396,7 @@ export function V2SlotCard({
     </article>
   );
 }
+
 
 function formatProviderWarning(value: string | Record<string, unknown>) {
   if (typeof value === "string") return value;

--- a/apps/web/src/features/workflow/v2/slots/V2SlotWorkbenchModule.ts
+++ b/apps/web/src/features/workflow/v2/slots/V2SlotWorkbenchModule.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { v2Api } from "../../../../api/v2Client.ts";
+import { effectiveSlotPrompt } from "../../../../types-v2.ts";
 import type {
   AssetVersionV2,
   SlotVersionsResponseV2,
@@ -14,7 +15,7 @@ import {
   buildSlotReferenceAttachRequest,
   slotReferenceUploadFormData,
 } from "../../../../workflow-v2/slotControls.ts";
-import { useSlotMicroEdit } from "./useSlotMicroEdit.ts";
+import { slotDraftHasPromptChanges, useSlotMicroEdit } from "./useSlotMicroEdit.ts";
 
 export type V2SlotAction =
   | { type: "open"; slotId: string }
@@ -92,6 +93,11 @@ async function ensureV2SlotDraftReferences(args: V2SlotWorkbenchModuleArgs, slot
 
 export function useV2SlotWorkbenchModule(args: V2SlotWorkbenchModuleArgs): V2SlotWorkbenchModule {
   const microEdit = useSlotMicroEdit();
+  const rebaseSlotDrafts = microEdit.rebaseSlots;
+
+  useEffect(() => {
+    rebaseSlotDrafts(args.slots);
+  }, [args.slots, rebaseSlotDrafts]);
 
   const refreshSlot = useCallback(async (slotId: string) => {
     if (!args.workflowId) return;
@@ -121,7 +127,7 @@ export function useV2SlotWorkbenchModule(args: V2SlotWorkbenchModuleArgs): V2Slo
         const draft = microEdit.state.draftsBySlotId[action.slotId];
         const request = buildSlotCandidateRegenerateRequest(
           draft ?? {
-            prompt: slot.slot_prompt ?? "",
+            prompt: effectiveSlotPrompt(slot),
             negative_prompt: slot.negative_prompt ?? "",
             reference_asset_ids: slot.explicit_reference_ids ?? [],
             uploaded_asset_ids: [],
@@ -130,27 +136,42 @@ export function useV2SlotWorkbenchModule(args: V2SlotWorkbenchModuleArgs): V2Slo
           slot,
           action.sourceAction ?? "slot_micro_prompt_send",
         );
-        await v2Api.updateSlotPrompt(args.workflowId, action.slotId, {
-          slot_prompt: request.slot_prompt,
-          negative_prompt: request.negative_prompt,
-        });
-        await ensureV2SlotDraftReferences(args, slot);
-        for (const libraryEntityId of request.library_entity_ids) {
-          await v2Api.registerLibraryReference(
-            args.workflowId,
-            buildSlotLibraryReferenceRegistration(action.slotId, libraryEntityId, null, slot.slot_type),
-          );
+        const promptPersisted = Boolean(draft && slotDraftHasPromptChanges(draft));
+        let savedSlot: WorkflowSlotV2 | undefined;
+        microEdit.setSubmitting(action.slotId, true);
+        try {
+          if (promptPersisted) {
+            const nextWorkflow = await v2Api.updateSlotPrompt(args.workflowId, action.slotId, {
+              slot_prompt: request.slot_prompt,
+              negative_prompt: request.negative_prompt,
+            });
+            savedSlot = nextWorkflow.slots.find((candidate) => candidate.slot_id === action.slotId);
+          }
+          await ensureV2SlotDraftReferences(args, slot);
+          for (const libraryEntityId of request.library_entity_ids) {
+            await v2Api.registerLibraryReference(
+              args.workflowId,
+              buildSlotLibraryReferenceRegistration(action.slotId, libraryEntityId, null, slot.slot_type),
+            );
+          }
+          for (const sourceAssetId of request.reference_asset_ids) {
+            await v2Api.registerReferenceAsset(
+              args.workflowId,
+              buildSlotReferenceAssetRegistration(action.slotId, { kind: "existing_v2_asset_version", asset_id: sourceAssetId }, slot.slot_type),
+            );
+            await v2Api.attachReference(args.workflowId, buildSlotReferenceAttachRequest(action.slotId, sourceAssetId, slot.slot_type));
+          }
+          const regenerated = await v2Api.regenerateSlot(args.workflowId, action.slotId);
+          savedSlot = regenerated.workflow?.slots.find((candidate) => candidate.slot_id === action.slotId) ?? savedSlot;
+          if (savedSlot) microEdit.markClean(action.slotId, savedSlot, promptPersisted);
+          else await args.onWorkflowRefresh();
+          await refreshSlot(action.slotId);
+          await args.onAssetRefresh();
+        } catch (error) {
+          microEdit.setSubmitting(action.slotId, false, error instanceof Error ? error.message : "Slot action failed");
+          throw error;
         }
-        for (const sourceAssetId of request.reference_asset_ids) {
-          await v2Api.registerReferenceAsset(
-            args.workflowId,
-            buildSlotReferenceAssetRegistration(action.slotId, { kind: "existing_v2_asset_version", asset_id: sourceAssetId }, slot.slot_type),
-          );
-          await v2Api.attachReference(args.workflowId, buildSlotReferenceAttachRequest(action.slotId, sourceAssetId, slot.slot_type));
-        }
-        await v2Api.regenerateSlot(args.workflowId, action.slotId);
-        await refreshSlot(action.slotId);
-        await args.onAssetRefresh();
+        microEdit.setSubmitting(action.slotId, false);
         return;
       }
       if (action.type === "generate_version") {

--- a/apps/web/src/features/workflow/v2/slots/slotPromptEditorState.ts
+++ b/apps/web/src/features/workflow/v2/slots/slotPromptEditorState.ts
@@ -1,0 +1,64 @@
+import { effectiveSlotPrompt, type WorkflowSlotV2 } from "../../../../types-v2.ts";
+
+export type SlotPromptEditorState = {
+  prompt: string;
+  negativePrompt: string;
+  basePrompt: string;
+  baseNegativePrompt: string;
+  dirty: boolean;
+};
+
+export type SlotPromptSaveResult =
+  | { ok: true; slot: Pick<WorkflowSlotV2, "slot_prompt" | "system_suggested_prompt" | "user_prompt" | "negative_prompt"> }
+  | { ok: false };
+
+export function createSlotPromptEditorState(slot: Pick<WorkflowSlotV2, "slot_prompt" | "system_suggested_prompt" | "user_prompt" | "negative_prompt">): SlotPromptEditorState {
+  const prompt = effectiveSlotPrompt(slot);
+  const negativePrompt = slot.negative_prompt ?? "";
+  return { prompt, negativePrompt, basePrompt: prompt, baseNegativePrompt: negativePrompt, dirty: false };
+}
+
+export function rebaseSlotPromptEditorState(current: SlotPromptEditorState, server: SlotPromptEditorState): SlotPromptEditorState {
+  if (current.dirty) return current;
+  return current.prompt === server.prompt && current.negativePrompt === server.negativePrompt ? current : server;
+}
+
+export async function saveSlotPromptEditorState(
+  submitted: SlotPromptEditorState,
+  save: () => Promise<SlotPromptSaveResult> | SlotPromptSaveResult,
+  latest: () => SlotPromptEditorState = () => submitted,
+) {
+  const result = await save();
+  if (!result.ok) return { saved: false as const, state: latest() };
+  return {
+    saved: true as const,
+    state: reconcileSuccessfulSlotPromptSave(submitted, latest(), createSlotPromptEditorState(result.slot)),
+  };
+}
+
+export async function runSlotPromptEditorGeneration(
+  current: SlotPromptEditorState,
+  save: () => Promise<SlotPromptSaveResult> | SlotPromptSaveResult,
+  generate: () => Promise<unknown> | unknown,
+) {
+  const saved = current.dirty ? await saveSlotPromptEditorState(current, save) : { saved: true as const, state: current };
+  if (!saved.saved) return saved;
+  await generate();
+  return saved;
+}
+
+function reconcileSuccessfulSlotPromptSave(
+  submitted: SlotPromptEditorState,
+  latest: SlotPromptEditorState,
+  server: SlotPromptEditorState,
+): SlotPromptEditorState {
+  const prompt = latest.prompt === submitted.prompt ? server.prompt : latest.prompt;
+  const negativePrompt = latest.negativePrompt === submitted.negativePrompt ? server.negativePrompt : latest.negativePrompt;
+  return {
+    prompt,
+    negativePrompt,
+    basePrompt: server.basePrompt,
+    baseNegativePrompt: server.baseNegativePrompt,
+    dirty: prompt !== server.basePrompt || negativePrompt !== server.baseNegativePrompt,
+  };
+}

--- a/apps/web/src/features/workflow/v2/slots/slotPromptFlush.ts
+++ b/apps/web/src/features/workflow/v2/slots/slotPromptFlush.ts
@@ -1,6 +1,6 @@
-import type { V2SlotPromptUpdateRequest, WorkflowSlotV2 } from "../../../../types-v2.ts";
+import { effectiveSlotPrompt, type V2SlotPromptUpdateRequest, type WorkflowSlotV2 } from "../../../../types-v2.ts";
 import type { SlotMicroEditDraft } from "./useSlotMicroEdit.ts";
-import { slotDraftSubmitPayload } from "./useSlotMicroEdit.ts";
+import { slotDraftHasPromptChanges, slotDraftSubmitPayload } from "./useSlotMicroEdit.ts";
 
 export type V2SlotDraftFlush = {
   slotId: string;
@@ -18,7 +18,7 @@ export function collectDirtyV2SlotDraftFlushes(
   const flushes: V2SlotDraftFlush[] = [];
 
   for (const [slotId, draft] of Object.entries(draftsBySlotId)) {
-    if (!draft?.dirty) continue;
+    if (!draft?.dirty || draft.isSubmitting) continue;
     const slot = slotById.get(slotId);
     if (!slot) continue;
     const promptPatch = buildDirtyV2SlotPromptPatch(slot, draft);
@@ -31,16 +31,17 @@ export function collectDirtyV2SlotDraftFlushes(
 }
 
 export function buildDirtyV2SlotPromptPatch(slot: WorkflowSlotV2, draft: SlotMicroEditDraft): V2SlotPromptUpdateRequest | null {
+  if (!slotDraftHasPromptChanges(draft)) return null;
   const payload = slotDraftSubmitPayload(draft);
-  const nextPrompt = normalizePrompt(payload.slot_prompt);
-  const nextNegativePrompt = normalizePrompt(payload.negative_prompt ?? "");
-  const currentPrompt = normalizePrompt(slot.slot_prompt ?? "");
-  const currentNegativePrompt = normalizePrompt(slot.negative_prompt ?? "");
+  const nextPrompt = payload.slot_prompt;
+  const nextNegativePrompt = payload.negative_prompt ?? "";
+  const currentPrompt = effectiveSlotPrompt(slot);
+  const currentNegativePrompt = slot.negative_prompt ?? "";
 
   if (nextPrompt === currentPrompt && nextNegativePrompt === currentNegativePrompt) return null;
   return {
     slot_prompt: nextPrompt,
-    negative_prompt: nextNegativePrompt || undefined,
+    negative_prompt: nextNegativePrompt,
   };
 }
 
@@ -55,8 +56,4 @@ export function v2SlotDraftHasPendingReferences(draft: SlotMicroEditDraft) {
     if (attachment.source_asset_id && !attachment.relation_id) return true;
     return attachment.status === "draft" || attachment.status === "registering" || attachment.status === "registered";
   });
-}
-
-function normalizePrompt(value: string) {
-  return value.trim();
 }

--- a/apps/web/src/features/workflow/v2/slots/useSlotMicroEdit.ts
+++ b/apps/web/src/features/workflow/v2/slots/useSlotMicroEdit.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { WorkflowSlotV2 } from "../../../../types-v2.ts";
+import { effectiveSlotPrompt, type WorkflowSlotV2 } from "../../../../types-v2.ts";
 
 export type SlotMicroEditAttachmentStatus = "draft" | "registering" | "registered" | "attached" | "failed";
 
@@ -27,8 +27,34 @@ export interface SlotMicroEditDraft {
   library_entity_ids: string[];
   attachments: SlotMicroEditAttachment[];
   dirty: boolean;
+  promptDirty: boolean;
+  referenceDirty: boolean;
+  base_prompt: string;
+  base_negative_prompt: string;
   isSubmitting: boolean;
+  submissionDepth?: number;
+  promptRevision?: number;
+  referenceRevision?: number;
   error?: string;
+  serverBaseline?: SlotMicroEditServerBaseline;
+  pendingRebase?: SlotMicroEditServerBaseline;
+  submissionBaseline?: SlotMicroEditSubmissionBaseline;
+}
+
+interface SlotMicroEditSubmissionBaseline {
+  prompt: string;
+  promptRevision: number;
+  referenceRevision: number;
+}
+
+export interface SlotMicroEditServerBaseline {
+  prompt: string;
+  slot_prompt?: string;
+  system_suggested_prompt?: string;
+  user_prompt?: string;
+  negative_prompt: string;
+  reference_asset_ids: string[];
+  attachments: SlotMicroEditAttachment[];
 }
 
 export interface SlotMicroEditState {
@@ -60,24 +86,102 @@ export function closeSlotMicroEdit(state: SlotMicroEditState): SlotMicroEditStat
   return { ...state, openSlotId: null };
 }
 
+/** Reconciles one existing draft with a fresh server slot without creating drafts. */
+export function rebaseSlotMicroEditDraft(state: SlotMicroEditState, slot: WorkflowSlotV2): SlotMicroEditState {
+  const draft = state.draftsBySlotId[slot.slot_id];
+  if (!draft) return state;
+
+  const serverBaseline = serverBaselineFromSlot(slot);
+  if (draft.isSubmitting) {
+    const nextDraft = sameServerBaseline(draft.pendingRebase, serverBaseline) ? draft : { ...draft, pendingRebase: serverBaseline };
+    return sameDraft(draft, nextDraft) ? state : updateDraft(state, slot.slot_id, nextDraft);
+  }
+  const nextDraft = draft.promptDirty
+    ? { ...draft, serverBaseline }
+    : {
+      ...draft,
+      prompt: serverBaseline.prompt,
+      negative_prompt: serverBaseline.negative_prompt,
+      base_prompt: serverBaseline.prompt,
+      base_negative_prompt: serverBaseline.negative_prompt,
+      promptDirty: false,
+      reference_asset_ids: draft.referenceDirty ? draft.reference_asset_ids : serverBaseline.reference_asset_ids,
+      attachments: draft.referenceDirty ? draft.attachments : serverBaseline.attachments,
+      dirty: draft.referenceDirty,
+      serverBaseline,
+    };
+  if (sameDraft(draft, nextDraft)) return state;
+  return {
+    ...state,
+    draftsBySlotId: { ...state.draftsBySlotId, [slot.slot_id]: nextDraft },
+  };
+}
+
+/** Reconciles existing drafts with a fresh slot collection and removes archived slots. */
+export function rebaseSlotMicroEditState(
+  state: SlotMicroEditState,
+  slots: WorkflowSlotV2[],
+  options: { authoritative?: boolean; archivedSlotIds?: string[]; removedSlotIds?: string[] } = {},
+): SlotMicroEditState {
+  const slotsById = new Map(slots.map((slot) => [slot.slot_id, slot]));
+  const removedSlotIds = new Set([...(options.archivedSlotIds ?? []), ...(options.removedSlotIds ?? [])]);
+  let nextState = state;
+
+  for (const slotId of Object.keys(state.draftsBySlotId)) {
+    const slot = slotsById.get(slotId);
+    if (slot && !removedSlotIds.has(slotId)) {
+      nextState = rebaseSlotMicroEditDraft(nextState, slot);
+      continue;
+    }
+    if (!removedSlotIds.has(slotId) && !options.authoritative) continue;
+    const { [slotId]: _removed, ...remainingDrafts } = nextState.draftsBySlotId;
+    nextState = {
+      ...nextState,
+      openSlotId: nextState.openSlotId === slotId ? null : nextState.openSlotId,
+      draftsBySlotId: remainingDrafts,
+    };
+  }
+
+  if (nextState.openSlotId && (removedSlotIds.has(nextState.openSlotId) || (options.authoritative && !slotsById.has(nextState.openSlotId)))) {
+    return { ...nextState, openSlotId: null };
+  }
+  return nextState;
+}
+
 export function updateSlotMicroEditPrompt(state: SlotMicroEditState, slotId: string, prompt: string): SlotMicroEditState {
   const draft = ensureDraft(state, slotId);
+  const promptDirty = prompt !== draft.base_prompt;
   return {
     ...state,
     draftsBySlotId: {
       ...state.draftsBySlotId,
-      [slotId]: { ...draft, prompt, dirty: true, error: undefined },
+      [slotId]: {
+        ...draft,
+        prompt,
+        promptRevision: prompt === draft.prompt ? draft.promptRevision : revisionOf(draft.promptRevision) + 1,
+        promptDirty,
+        dirty: promptDirty || draft.referenceDirty,
+        error: undefined,
+      },
     },
   };
 }
 
 export function updateSlotMicroEditNegativePrompt(state: SlotMicroEditState, slotId: string, negativePrompt: string): SlotMicroEditState {
   const draft = ensureDraft(state, slotId);
+  const promptDirty = draft.prompt !== draft.base_prompt || negativePrompt !== draft.base_negative_prompt;
   return {
     ...state,
     draftsBySlotId: {
       ...state.draftsBySlotId,
-      [slotId]: { ...draft, negative_prompt: negativePrompt, dirty: true, error: undefined },
+      [slotId]: {
+        ...draft,
+        negative_prompt: negativePrompt,
+        promptRevision: negativePrompt === draft.negative_prompt ? draft.promptRevision : revisionOf(draft.promptRevision) + 1,
+        promptDirty,
+        dirty: promptDirty || draft.referenceDirty,
+        error: undefined,
+      },
     },
   };
 }
@@ -90,13 +194,20 @@ export function addSlotDraftReference(state: SlotMicroEditState, slotId: string,
     uploaded_asset_ids: reference.source === "uploaded_asset" ? addUnique(draft.uploaded_asset_ids, reference.asset_id) : draft.uploaded_asset_ids,
     library_entity_ids: reference.source === "library_entity" ? addUnique(draft.library_entity_ids, reference.entity_id) : draft.library_entity_ids,
     attachments: upsertAttachment(draft.attachments, attachmentFromDraftReference(reference)),
+    referenceRevision: revisionOf(draft.referenceRevision) + 1,
+    referenceDirty: true,
     dirty: true,
     error: undefined,
   });
   return updateDraft(state, slotId, nextDraft);
 }
 
-export function addSlotDraftAttachment(state: SlotMicroEditState, slotId: string, attachment: SlotMicroEditAttachment): SlotMicroEditState {
+export function addSlotDraftAttachment(
+  state: SlotMicroEditState,
+  slotId: string,
+  attachment: SlotMicroEditAttachment,
+  trackRevision = true,
+): SlotMicroEditState {
   const draft = ensureDraft(state, slotId);
   return updateDraft(
     state,
@@ -104,6 +215,8 @@ export function addSlotDraftAttachment(state: SlotMicroEditState, slotId: string
     syncDraftReferenceArrays({
       ...draft,
       attachments: upsertAttachment(draft.attachments, normalizeAttachment(attachment)),
+      referenceRevision: trackRevision ? revisionOf(draft.referenceRevision) + 1 : draft.referenceRevision,
+      referenceDirty: true,
       dirty: true,
       error: undefined,
     }),
@@ -116,7 +229,8 @@ export function updateSlotDraftAttachment(
   attachmentId: string,
   patch: Partial<SlotMicroEditAttachment>,
 ): SlotMicroEditState {
-  const draft = ensureDraft(state, slotId);
+  const draft = state.draftsBySlotId[slotId];
+  if (!draft) return state;
   return updateDraft(
     state,
     slotId,
@@ -125,6 +239,7 @@ export function updateSlotDraftAttachment(
       attachments: draft.attachments.map((attachment) =>
         attachment.id === attachmentId ? normalizeAttachment({ ...attachment, ...patch }) : attachment,
       ),
+      referenceDirty: true,
       dirty: true,
       error: patch.status === "failed" ? patch.error : undefined,
     }),
@@ -134,25 +249,147 @@ export function updateSlotDraftAttachment(
 export function removeSlotDraftReference(state: SlotMicroEditState, slotId: string, reference: DraftReference): SlotMicroEditState {
   const draft = ensureDraft(state, slotId);
   const assetId = reference.source === "reference_asset" || reference.source === "uploaded_asset" ? reference.asset_id : "";
-  return updateDraft(state, slotId, syncDraftReferenceArrays({
+  const nextDraft = syncDraftReferenceArrays({
     ...draft,
     reference_asset_ids: assetId ? withoutValue(draft.reference_asset_ids, assetId) : draft.reference_asset_ids,
     uploaded_asset_ids: reference.source === "uploaded_asset" ? withoutValue(draft.uploaded_asset_ids, reference.asset_id) : draft.uploaded_asset_ids,
     library_entity_ids: reference.source === "library_entity" ? withoutValue(draft.library_entity_ids, reference.entity_id) : draft.library_entity_ids,
     attachments: draft.attachments.filter((attachment) => !attachmentMatchesReference(attachment, reference)),
-    dirty: true,
     error: undefined,
-  }));
+  });
+  const changed = !sameStrings(draft.reference_asset_ids, nextDraft.reference_asset_ids) ||
+    !sameStrings(draft.uploaded_asset_ids, nextDraft.uploaded_asset_ids) ||
+    !sameStrings(draft.library_entity_ids, nextDraft.library_entity_ids) ||
+    !sameAttachments(draft.attachments, nextDraft.attachments);
+  if (!changed) return state;
+  const referenceDirty = draft.serverBaseline ? draftReferencesDifferFromBaseline(nextDraft, draft.serverBaseline) : true;
+  return updateDraft(state, slotId, {
+    ...nextDraft,
+    referenceRevision: revisionOf(draft.referenceRevision) + 1,
+    referenceDirty,
+    dirty: draft.promptDirty || referenceDirty,
+  });
 }
 
 export function setSlotDraftSubmitting(state: SlotMicroEditState, slotId: string, isSubmitting: boolean, error?: string): SlotMicroEditState {
-  const draft = ensureDraft(state, slotId);
-  return updateDraft(state, slotId, { ...draft, isSubmitting, error });
+  if (isSubmitting) {
+    const draft = ensureDraft(state, slotId);
+    return updateDraft(state, slotId, {
+      ...draft,
+      isSubmitting: true,
+      submissionDepth: submissionDepthOf(draft) + 1,
+      error,
+      submissionBaseline: draft.submissionBaseline ?? {
+        prompt: draft.prompt,
+        promptRevision: revisionOf(draft.promptRevision),
+        referenceRevision: revisionOf(draft.referenceRevision),
+      },
+    });
+  }
+
+  const draft = state.draftsBySlotId[slotId];
+  if (!draft) return state;
+  const settledState = draft.pendingRebase || error
+    ? completeSlotDraftSubmission(state, slotId, { error })
+    : state;
+  const settledDraft = settledState.draftsBySlotId[slotId];
+  if (!settledDraft) return settledState;
+  const submissionDepth = Math.max(0, submissionDepthOf(settledDraft) - 1);
+  return updateDraft(settledState, slotId, {
+    ...settledDraft,
+    isSubmitting: submissionDepth > 0,
+    submissionDepth,
+    error: error ?? settledDraft.error,
+    submissionBaseline: submissionDepth > 0 ? settledDraft.submissionBaseline : undefined,
+  });
 }
 
-export function markSlotDraftClean(state: SlotMicroEditState, slotId: string): SlotMicroEditState {
-  const draft = ensureDraft(state, slotId);
-  return updateDraft(state, slotId, { ...draft, dirty: false, isSubmitting: false, error: undefined });
+export function completeSlotDraftSubmission(
+  state: SlotMicroEditState,
+  slotId: string,
+  options: { slot?: WorkflowSlotV2; promptPersisted?: boolean; referenceBaselineAuthoritative?: boolean; error?: string } = {},
+): SlotMicroEditState {
+  const draft = state.draftsBySlotId[slotId];
+  if (!draft) return state;
+  const submissionDepth = submissionDepthOf(draft);
+  const isSubmitting = submissionDepth > 0;
+  const submissionBaseline = draft.submissionBaseline;
+  const promptChangedAfterSubmit = Boolean(submissionBaseline && revisionOf(draft.promptRevision) !== submissionBaseline.promptRevision);
+  const referencesChangedAfterSubmit = Boolean(submissionBaseline && revisionOf(draft.referenceRevision) !== submissionBaseline.referenceRevision);
+  const promptPersisted = Boolean(options.promptPersisted);
+  const returnedBaseline = options.slot ? serverBaselineFromSlot(options.slot) : undefined;
+  const incoming = options.error
+    ? draft.pendingRebase ?? returnedBaseline ?? draft.serverBaseline
+    : returnedBaseline
+      ? mergeSuccessfulSubmissionBaseline(
+        returnedBaseline,
+        draft.pendingRebase,
+        promptPersisted ? submissionBaseline?.prompt ?? draft.prompt : undefined,
+        options.referenceBaselineAuthoritative,
+      )
+      : draft.pendingRebase;
+  if (!incoming) {
+    return updateDraft(state, slotId, {
+      ...draft,
+      isSubmitting,
+      submissionDepth,
+      error: options.error,
+      submissionBaseline: isSubmitting ? submissionBaseline : undefined,
+    });
+  }
+  const serverBaseline = incoming;
+  const failed = Boolean(options.error);
+  const keepPrompt = failed || promptChangedAfterSubmit || (!promptPersisted && draft.promptDirty);
+  const prompt = keepPrompt ? draft.prompt : serverBaseline.prompt;
+  const negative_prompt = keepPrompt ? draft.negative_prompt : serverBaseline.negative_prompt;
+  const base_prompt = serverBaseline.prompt;
+  const base_negative_prompt = serverBaseline.negative_prompt;
+  const preserveReferences = (failed && draft.referenceDirty) || referencesChangedAfterSubmit;
+  const reference_asset_ids = preserveReferences ? draft.reference_asset_ids : serverBaseline.reference_asset_ids;
+  const uploaded_asset_ids = preserveReferences ? draft.uploaded_asset_ids : [];
+  const library_entity_ids = preserveReferences ? draft.library_entity_ids : [];
+  const attachments = preserveReferences ? draft.attachments : serverBaseline.attachments;
+  const referenceDirty = preserveReferences ? draftReferencesDifferFromBaseline(draft, serverBaseline) : false;
+  const promptDirty = keepPrompt
+    ? prompt !== base_prompt || (negative_prompt ?? "") !== base_negative_prompt
+    : false;
+  const nextDraft: SlotMicroEditDraft = {
+    ...draft,
+    prompt,
+    negative_prompt,
+    reference_asset_ids,
+    uploaded_asset_ids,
+    library_entity_ids,
+    attachments,
+    base_prompt,
+    base_negative_prompt,
+    promptDirty,
+    referenceDirty,
+    dirty: promptDirty || referenceDirty,
+    isSubmitting,
+    submissionDepth,
+    error: options.error,
+    serverBaseline,
+    pendingRebase: undefined,
+    submissionBaseline: isSubmitting ? submissionBaseline : undefined,
+  };
+  nextDraft.dirty = nextDraft.promptDirty || nextDraft.referenceDirty;
+  return sameDraft(draft, nextDraft) ? state : updateDraft(state, slotId, nextDraft);
+}
+
+export function markSlotDraftClean(
+  state: SlotMicroEditState,
+  slotId: string,
+  slot?: WorkflowSlotV2,
+  promptPersisted = true,
+  referenceBaselineAuthoritative = false,
+): SlotMicroEditState {
+  if (!state.draftsBySlotId[slotId]) return state;
+  return completeSlotDraftSubmission(state, slotId, { slot, promptPersisted, referenceBaselineAuthoritative });
+}
+
+export function slotDraftHasPromptChanges(draft: Pick<SlotMicroEditDraft, "promptDirty">) {
+  return draft.promptDirty;
 }
 
 export function slotDraftSubmitPayload(draft: SlotMicroEditDraft) {
@@ -176,29 +413,141 @@ export function useSlotMicroEdit(initialState: SlotMicroEditState = createInitia
   const updateNegativePrompt = useCallback((slotId: string, negativePrompt: string) => setState((current) => updateSlotMicroEditNegativePrompt(current, slotId, negativePrompt)), []);
   const addReference = useCallback((slotId: string, reference: DraftReference) => setState((current) => addSlotDraftReference(current, slotId, reference)), []);
   const removeReference = useCallback((slotId: string, reference: DraftReference) => setState((current) => removeSlotDraftReference(current, slotId, reference)), []);
-  const addAttachment = useCallback((slotId: string, attachment: SlotMicroEditAttachment) => setState((current) => addSlotDraftAttachment(current, slotId, attachment)), []);
+  const addAttachment = useCallback((slotId: string, attachment: SlotMicroEditAttachment, trackRevision = true) => setState((current) => addSlotDraftAttachment(current, slotId, attachment, trackRevision)), []);
   const updateAttachment = useCallback((slotId: string, attachmentId: string, patch: Partial<SlotMicroEditAttachment>) => setState((current) => updateSlotDraftAttachment(current, slotId, attachmentId, patch)), []);
   const setSubmitting = useCallback((slotId: string, isSubmitting: boolean, error?: string) => setState((current) => setSlotDraftSubmitting(current, slotId, isSubmitting, error)), []);
-  const markClean = useCallback((slotId: string) => setState((current) => markSlotDraftClean(current, slotId)), []);
-  return { state, setState, openSlot, closeSlot, updatePrompt, updateNegativePrompt, addReference, removeReference, addAttachment, updateAttachment, setSubmitting, markClean };
+  const markClean = useCallback((slotId: string, slot?: WorkflowSlotV2, promptPersisted = true, referenceBaselineAuthoritative = false) => setState((current) => markSlotDraftClean(current, slotId, slot, promptPersisted, referenceBaselineAuthoritative)), []);
+  const rebaseSlots = useCallback((slots: WorkflowSlotV2[], options?: { authoritative?: boolean; archivedSlotIds?: string[]; removedSlotIds?: string[] }) => setState((current) => rebaseSlotMicroEditState(current, slots, options)), []);
+  return { state, setState, openSlot, closeSlot, updatePrompt, updateNegativePrompt, addReference, removeReference, addAttachment, updateAttachment, setSubmitting, markClean, rebaseSlots };
 }
 
 function draftFromSlot(slot: WorkflowSlotV2): SlotMicroEditDraft {
+  const serverBaseline = serverBaselineFromSlot(slot);
   return {
-    prompt: slot.slot_prompt ?? "",
-    negative_prompt: slot.negative_prompt ?? "",
-    reference_asset_ids: [...(slot.explicit_reference_ids ?? [])],
+    prompt: serverBaseline.prompt,
+    negative_prompt: serverBaseline.negative_prompt,
+    reference_asset_ids: serverBaseline.reference_asset_ids,
     uploaded_asset_ids: [],
     library_entity_ids: [],
-    attachments: (slot.explicit_reference_ids ?? []).map((assetId) => ({
+    attachments: serverBaseline.attachments,
+    dirty: false,
+    promptDirty: false,
+    referenceDirty: false,
+    base_prompt: serverBaseline.prompt,
+    base_negative_prompt: serverBaseline.negative_prompt,
+    isSubmitting: false,
+    submissionDepth: 0,
+    promptRevision: 0,
+    referenceRevision: 0,
+    serverBaseline,
+  };
+}
+
+function serverBaselineFromSlot(slot: WorkflowSlotV2): SlotMicroEditServerBaseline {
+  const reference_asset_ids = [...(slot.explicit_reference_ids ?? [])];
+  return {
+    prompt: effectiveSlotPrompt(slot),
+    slot_prompt: slot.slot_prompt,
+    system_suggested_prompt: slot.system_suggested_prompt,
+    user_prompt: slot.user_prompt,
+    negative_prompt: slot.negative_prompt ?? "",
+    reference_asset_ids,
+    attachments: reference_asset_ids.map((assetId) => ({
       id: `reference:${assetId}`,
       source: "reference_asset",
       source_asset_id: assetId,
       status: "attached",
     })),
-    dirty: false,
-    isSubmitting: false,
   };
+}
+
+function mergeSuccessfulSubmissionBaseline(
+  returned: SlotMicroEditServerBaseline,
+  pending: SlotMicroEditServerBaseline | undefined,
+  persistedUserPrompt: string | undefined,
+  referenceBaselineAuthoritative = false,
+): SlotMicroEditServerBaseline {
+  if (!pending && persistedUserPrompt === undefined) return returned;
+  const merged = {
+    ...returned,
+    user_prompt: returned.user_prompt === undefined ? persistedUserPrompt : returned.user_prompt,
+    system_suggested_prompt: pending?.system_suggested_prompt ?? returned.system_suggested_prompt,
+    reference_asset_ids: referenceBaselineAuthoritative ? returned.reference_asset_ids : pending?.reference_asset_ids ?? returned.reference_asset_ids,
+    attachments: referenceBaselineAuthoritative ? returned.attachments : pending?.attachments ?? returned.attachments,
+  };
+  return { ...merged, prompt: effectiveSlotPrompt(merged) };
+}
+
+function draftReferencesDifferFromBaseline(draft: SlotMicroEditDraft, baseline: SlotMicroEditServerBaseline) {
+  if (!sameStringSet(draft.reference_asset_ids, baseline.reference_asset_ids) || draft.uploaded_asset_ids.length > 0) return true;
+  const baselineAssetIds = new Set(baseline.reference_asset_ids);
+  const unresolvedLibraryEntity = draft.library_entity_ids.some((entityId) => !draft.attachments.some((attachment) =>
+    attachment.library_entity_id === entityId && attachment.source_asset_id && baselineAssetIds.has(attachment.source_asset_id)
+  ));
+  if (unresolvedLibraryEntity) return true;
+  return draft.attachments.some((attachment) => attachment.status === "failed" || !attachment.source_asset_id);
+}
+
+function sameDraft(left: SlotMicroEditDraft, right: SlotMicroEditDraft) {
+  return left === right || (
+    left.prompt === right.prompt &&
+    left.negative_prompt === right.negative_prompt &&
+    left.base_prompt === right.base_prompt &&
+    left.base_negative_prompt === right.base_negative_prompt &&
+    left.dirty === right.dirty &&
+    left.promptDirty === right.promptDirty &&
+    left.referenceDirty === right.referenceDirty &&
+    left.isSubmitting === right.isSubmitting &&
+    submissionDepthOf(left) === submissionDepthOf(right) &&
+    revisionOf(left.promptRevision) === revisionOf(right.promptRevision) &&
+    revisionOf(left.referenceRevision) === revisionOf(right.referenceRevision) &&
+    left.error === right.error &&
+    sameStrings(left.reference_asset_ids, right.reference_asset_ids) &&
+    sameStrings(left.uploaded_asset_ids, right.uploaded_asset_ids) &&
+    sameStrings(left.library_entity_ids, right.library_entity_ids) &&
+    sameAttachments(left.attachments, right.attachments) &&
+    sameServerBaseline(left.serverBaseline, right.serverBaseline) &&
+    sameServerBaseline(left.pendingRebase, right.pendingRebase) &&
+    sameSubmissionBaseline(left.submissionBaseline, right.submissionBaseline)
+  );
+}
+
+function sameSubmissionBaseline(left: SlotMicroEditSubmissionBaseline | undefined, right: SlotMicroEditSubmissionBaseline | undefined) {
+  return left === right || Boolean(left && right &&
+    left.prompt === right.prompt &&
+    left.promptRevision === right.promptRevision &&
+    left.referenceRevision === right.referenceRevision);
+}
+
+function sameServerBaseline(left: SlotMicroEditServerBaseline | undefined, right: SlotMicroEditServerBaseline | undefined) {
+  return left === right || Boolean(left && right &&
+    left.prompt === right.prompt &&
+    left.slot_prompt === right.slot_prompt &&
+    left.system_suggested_prompt === right.system_suggested_prompt &&
+    left.user_prompt === right.user_prompt &&
+    left.negative_prompt === right.negative_prompt &&
+    sameStrings(left.reference_asset_ids, right.reference_asset_ids) &&
+    sameAttachments(left.attachments, right.attachments));
+}
+
+function sameStrings(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameStringSet(left: string[], right: string[]) {
+  if (left.length !== right.length) return false;
+  const rightValues = new Set(right);
+  return left.every((value) => rightValues.has(value));
+}
+
+function sameAttachments(left: SlotMicroEditAttachment[], right: SlotMicroEditAttachment[]) {
+  return left.length === right.length && left.every((attachment, index) => {
+    const other = right[index];
+    return attachment.id === other.id && attachment.source === other.source && attachment.preview_url === other.preview_url &&
+      attachment.source_asset_id === other.source_asset_id && attachment.relation_id === other.relation_id &&
+      attachment.library_entity_id === other.library_entity_id && attachment.library_asset_id === other.library_asset_id &&
+      attachment.filename === other.filename && attachment.semantic_type === other.semantic_type && attachment.status === other.status && attachment.error === other.error;
+  });
 }
 
 function ensureDraft(state: SlotMicroEditState, slotId: string): SlotMicroEditDraft {
@@ -210,7 +559,14 @@ function ensureDraft(state: SlotMicroEditState, slotId: string): SlotMicroEditDr
     library_entity_ids: [],
     attachments: [],
     dirty: false,
+    promptDirty: false,
+    referenceDirty: false,
+    base_prompt: "",
+    base_negative_prompt: "",
     isSubmitting: false,
+    submissionDepth: 0,
+    promptRevision: 0,
+    referenceRevision: 0,
   };
 }
 
@@ -307,6 +663,14 @@ function attachmentIdentity(attachment: Pick<SlotMicroEditAttachment, "id" | "so
 
 function cleanString(value?: string | null) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function revisionOf(value?: number) {
+  return value ?? 0;
+}
+
+function submissionDepthOf(draft: Pick<SlotMicroEditDraft, "isSubmitting" | "submissionDepth">) {
+  return draft.submissionDepth ?? (draft.isSubmitting ? 1 : 0);
 }
 
 function scrubInlineMedia(value: string) {

--- a/apps/web/src/features/workflow/v2/slots/useV2SlotOperations.ts
+++ b/apps/web/src/features/workflow/v2/slots/useV2SlotOperations.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { v2Api } from "../../../../api/v2Client.ts";
 import type { AssetLibraryEntitySummary, AssetLibraryReference } from "../../../../types.ts";
 import type { PromptGenerateContext } from "../../../../components/PromptComposer.tsx";
+import { effectiveSlotPrompt } from "../../../../types-v2.ts";
 import type {
   AssetVersionV2,
   V2ReferenceAttachRequest,
@@ -14,6 +15,7 @@ import type {
 } from "../../../../types-v2.ts";
 import type { V2SlotReferenceRemoval } from "../../types.ts";
 import { shouldApplyWorkflowScopedResult } from "../../../../workflow/sessionGuards.ts";
+import type { V2WorkflowApplicationCapture } from "../../graph/v2WorkflowApplicationRevisionGuard.ts";
 import { isAllowedFreeAbsorbTarget } from "../../../../workflow-v2/agentRouting.ts";
 import {
   buildAddSlotReferenceRequest,
@@ -34,8 +36,9 @@ import {
   isV2StoryboardShotItem,
   v2EditableItemPrompt,
 } from "../v2PromptModel.ts";
-import type { SlotMicroEditAttachment, SlotMicroEditDraft, useSlotMicroEdit } from "./useSlotMicroEdit.ts";
+import { slotDraftHasPromptChanges, type SlotMicroEditAttachment, type SlotMicroEditDraft, type useSlotMicroEdit } from "./useSlotMicroEdit.ts";
 import { collectDirtyV2SlotDraftFlushes } from "./slotPromptFlush.ts";
+import { reconcileV2SlotMutationWorkflow } from "./v2SlotMutationWorkflowGuard.ts";
 import {
   assetLibraryEntityTypeForV2ImageSlot,
   v2ImageSlotMatchesAssetLibraryEntity,
@@ -68,6 +71,8 @@ type V2SlotOperationsArgs = {
   refreshV2WorkflowGraph: (workflowId: string) => Promise<WorkflowV2 | null>;
   syncV2Snapshot: (workflowId: string) => Promise<unknown>;
   refreshV2AssetsAndRetryMissing: (workflowId: string, reason: string, workflow?: WorkflowV2 | null) => Promise<unknown>;
+  captureV2WorkflowApplicationRevision: (workflowId: string) => V2WorkflowApplicationCapture;
+  isCurrentV2WorkflowApplicationRevision: (capture: V2WorkflowApplicationCapture, currentActiveWorkflowId: string | null) => boolean;
   selectedNodeIdRef: React.MutableRefObject<string>;
 };
 
@@ -81,6 +86,41 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   function activeWorkflowId() {
     const workflowId = argsRef.current.workflowId;
     return workflowId && argsRef.current.currentWorkflowIsV2() ? workflowId : null;
+  }
+
+  function captureSlotMutation(workflowId: string) {
+    return argsRef.current.captureV2WorkflowApplicationRevision(workflowId);
+  }
+
+  async function applySlotMutationWorkflow(
+    workflowId: string,
+    capture: V2WorkflowApplicationCapture,
+    workflow: WorkflowV2 | null,
+    options?: { refreshAssetsReason?: string | false },
+  ) {
+    const reconciled = await reconcileV2SlotMutationWorkflow({
+      workflowId,
+      capture,
+      activeWorkflowId: argsRef.current.activeWorkflowIdRef.current,
+      isCurrentRevision: argsRef.current.isCurrentV2WorkflowApplicationRevision,
+      returnedWorkflow: workflow,
+      applyWorkflowV2: (nextWorkflow) => argsRef.current.applyWorkflowV2(nextWorkflow, options),
+      refreshLatestWorkflow: () => argsRef.current.refreshV2WorkflowGraph(workflowId),
+    });
+    if (reconciled.stale && !reconciled.workflow) {
+      throw new Error("V2 slot changed while this request was in flight. Review the latest state and retry.");
+    }
+    return reconciled;
+  }
+
+  function requireFreshSlotMutation(result: { stale: boolean }) {
+    if (result.stale) throw new Error("V2 slot changed while this request was in flight. Latest state loaded; review and retry.");
+  }
+
+  async function requireFreshReferenceMutation(workflowId: string, capture: V2WorkflowApplicationCapture) {
+    const reconciled = await applySlotMutationWorkflow(workflowId, capture, null);
+    requireFreshSlotMutation(reconciled);
+    return reconciled;
   }
 
   async function saveV2ItemPrompt(item: WorkflowItemV2, prompt: string) {
@@ -109,18 +149,28 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
 
   async function saveV2SlotPrompt(slotId: string, prompt: string, negativePrompt?: string) {
     const workflowId = activeWorkflowId();
-    if (!workflowId) return;
+    if (!workflowId) return { ok: false } as const;
+    const capture = captureSlotMutation(workflowId);
     try {
       const nextWorkflow = await v2Api.updateSlotPrompt(workflowId, slotId, {
-        slot_prompt: prompt.trim(),
-        negative_prompt: negativePrompt?.trim() || undefined,
+        slot_prompt: prompt,
+        negative_prompt: negativePrompt,
       });
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await argsRef.current.applyWorkflowV2(nextWorkflow);
-      argsRef.current.v2SlotMicroEdit.markClean(slotId);
+      const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+      if (reconciled.stale) {
+        argsRef.current.setStatus(`${slotId} changed while saving; latest state loaded. Review and retry.`);
+        return { ok: false } as const;
+      }
+      const savedSlot = reconciled.workflow?.slots.find((slot) => slot.slot_id === slotId);
+      if (!savedSlot) {
+        argsRef.current.setStatus(`V2 slot prompt update did not return ${slotId}.`);
+        return { ok: false } as const;
+      }
       argsRef.current.setStatus(`${slotId} prompt saved`);
+      return { ok: true, slot: savedSlot } as const;
     } catch (error) {
       argsRef.current.setStatus(error instanceof Error ? error.message : "V2 slot prompt update failed");
+      return { ok: false } as const;
     }
   }
 
@@ -188,18 +238,26 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   }
 
   async function applyV2ReferenceArtifacts(
+    workflowId: string,
+    capture: V2WorkflowApplicationCapture,
     nextWorkflow: WorkflowV2 | null | undefined,
     assets: AssetVersionV2[] = [],
     relations: WorkflowAssetRelationV2[] = [],
   ) {
     if (nextWorkflow) {
-      await argsRef.current.applyWorkflowV2(nextWorkflow);
-      return;
+      const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+      requireFreshSlotMutation(reconciled);
+      return reconciled.workflow;
     }
-    if (!assets.length && !relations.length) return;
-    const currentWorkflow = argsRef.current.workflowV2;
-    if (!currentWorkflow) return;
-    await argsRef.current.applyWorkflowV2(mergeV2ReferenceArtifacts(currentWorkflow, assets, relations));
+    if (!assets.length && !relations.length) {
+      return (await requireFreshReferenceMutation(workflowId, capture)).workflow;
+    }
+    const freshness = await requireFreshReferenceMutation(workflowId, capture);
+    const currentWorkflow = freshness.workflow ?? argsRef.current.workflowV2;
+    if (!currentWorkflow) return null;
+    const reconciled = await applySlotMutationWorkflow(workflowId, capture, mergeV2ReferenceArtifacts(currentWorkflow, assets, relations));
+    requireFreshSlotMutation(reconciled);
+    return reconciled.workflow;
   }
 
   async function applyRegisteredV2SlotReference(
@@ -207,13 +265,15 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     slotId: string,
     semanticType: string | null | undefined,
     registered: V2RegisterReferenceResponse,
+    capture: V2WorkflowApplicationCapture,
   ) {
     if (registered.workflow || registered.relation) {
-      await applyV2ReferenceArtifacts(registered.workflow, [registered.asset], registered.relation ? [registered.relation] : []);
-      return registered.relation ?? null;
+      const workflow = await applyV2ReferenceArtifacts(workflowId, capture, registered.workflow, [registered.asset], registered.relation ? [registered.relation] : []);
+      return { relation: registered.relation ?? null, workflow };
     }
     const sourceAssetId = registered.source_asset_id || registered.asset.asset_id;
     const sourceVersionId = registered.asset.version_id || registered.asset.asset_id || sourceAssetId;
+    const attachCapture = captureSlotMutation(workflowId);
     const attached = await v2Api.attachSlotReference(
       workflowId,
       slotId,
@@ -222,18 +282,21 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
         referenceRoleForV2SemanticType(semanticType),
       ),
     );
-    if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return null;
-    await argsRef.current.refreshV2WorkflowGraph(workflowId);
+    await requireFreshReferenceMutation(workflowId, attachCapture);
+    const workflow = await argsRef.current.refreshV2WorkflowGraph(workflowId);
     await argsRef.current.syncV2Snapshot(workflowId);
     return {
-      relation_id: typeof attached.relation_id === "string" ? attached.relation_id : null,
-      relation_type: "reference_for_slot",
-      workflow_id: workflowId,
-      slot_id: slotId,
-      source_asset_id: sourceAssetId,
-      asset_id: sourceAssetId,
-      version_id: sourceVersionId,
-      semantic_type: semanticType ?? null,
+      relation: {
+        relation_id: typeof attached.relation_id === "string" ? attached.relation_id : null,
+        relation_type: "reference_for_slot",
+        workflow_id: workflowId,
+        slot_id: slotId,
+        source_asset_id: sourceAssetId,
+        asset_id: sourceAssetId,
+        version_id: sourceVersionId,
+        semantic_type: semanticType ?? null,
+      },
+      workflow,
     };
   }
 
@@ -245,21 +308,21 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     const references = uniqueAssetReferences(context?.asset_references ?? []);
     for (const reference of references) {
       if (reference.reference_source === "asset_library" && reference.entity_id) {
+        const capture = captureSlotMutation(workflowId);
         const registered = await v2Api.registerLibraryReference(
           workflowId,
           buildSlotLibraryReferenceRegistration(slot.slot_id, reference.entity_id, reference.asset_id, slot.slot_type),
         );
-        if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-        await applyRegisteredV2SlotReference(workflowId, slot.slot_id, slot.slot_type, registered);
+        await applyRegisteredV2SlotReference(workflowId, slot.slot_id, slot.slot_type, registered, capture);
         continue;
       }
       if (!reference.asset_id) continue;
+      const capture = captureSlotMutation(workflowId);
       const attached = await v2Api.attachReference(
         workflowId,
         buildSlotReferenceAttachRequest(slot.slot_id, reference.asset_id, slot.slot_type),
       );
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(attached.workflow, [], attached.relation ? [attached.relation] : []);
+      await applyV2ReferenceArtifacts(workflowId, capture, attached.workflow, [], attached.relation ? [attached.relation] : []);
     }
   }
 
@@ -271,6 +334,7 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     const references = uniqueAssetReferences(context?.asset_references ?? []);
     for (const reference of references) {
       if (!reference.asset_id) continue;
+      const capture = captureSlotMutation(workflowId);
       const response = await v2Api.attachReference(workflowId, {
         target_type: "item",
         target_id: item.item_id,
@@ -282,8 +346,7 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
           library_entity_id: reference.entity_id ?? null,
         },
       });
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(response.workflow, [], response.relation ? [response.relation] : []);
+      await applyV2ReferenceArtifacts(workflowId, capture, response.workflow, [], response.relation ? [response.relation] : []);
     }
   }
 
@@ -302,17 +365,17 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
       semantic_type: slot.slot_type,
       status: "registering",
     }));
-    attachments.forEach((attachment) => argsRef.current.v2SlotMicroEdit.addAttachment(slotId, attachment));
     argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
+    attachments.forEach((attachment) => argsRef.current.v2SlotMicroEdit.addAttachment(slotId, attachment));
     try {
       const formData = new FormData();
       fileItems.forEach((file) => formData.append("files[]", file));
       formData.append("semantic_type", slot.slot_type);
       formData.append("entity_type", "uploaded_reference");
       formData.append("use_as_prompt", "true");
+      const capture = captureSlotMutation(workflowId);
       const response = await v2Api.uploadSlotReferenceAsset(workflowId, slotId, formData);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(response.workflow, response.assets, response.relations);
+      const appliedWorkflow = await applyV2ReferenceArtifacts(workflowId, capture, response.workflow, response.assets, response.relations);
       response.source_asset_ids.forEach((sourceAssetId, index) => {
         const asset = response.assets.find((candidate) => candidate.asset_id === sourceAssetId) ?? response.assets[index];
         const relation = relationForSourceAsset(response.relations, sourceAssetId, slotId);
@@ -325,6 +388,7 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
           error: undefined,
         });
       });
+      settleSuccessfulReferenceMutation(slotId, appliedWorkflow, response.source_asset_ids);
       argsRef.current.setStatus(`${slot.slot_type} reference uploaded`);
     } catch (error) {
       const message = error instanceof Error ? error.message : "V2 slot reference upload failed";
@@ -342,6 +406,7 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     const slot = v2SlotById(slotId);
     if (!slot || !entityId) return;
     const attachmentId = `library:${entityId}:`;
+    argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
     argsRef.current.v2SlotMicroEdit.addAttachment(slotId, {
       id: attachmentId,
       source: "asset_library",
@@ -350,33 +415,36 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
       status: "registering",
     });
     try {
+      const capture = captureSlotMutation(workflowId);
       const registered = await v2Api.registerLibraryReference(
         workflowId,
         buildSlotLibraryReferenceRegistration(slotId, entityId, null, slot.slot_type),
       );
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
+      await requireFreshReferenceMutation(workflowId, capture);
       argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachmentId, {
         source_asset_id: registered.source_asset_id,
         preview_url: assetPreviewUrl(registered.asset),
         status: "registered",
         error: undefined,
       });
-      const relation = await applyRegisteredV2SlotReference(workflowId, slotId, slot.slot_type, registered);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
+      const applied = await applyRegisteredV2SlotReference(workflowId, slotId, slot.slot_type, registered, capture);
       argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachmentId, {
         source_asset_id: registered.source_asset_id,
-        relation_id: relation?.relation_id,
+        relation_id: applied.relation?.relation_id,
         preview_url: assetPreviewUrl(registered.asset),
-        status: relation?.relation_id ? "attached" : "registered",
+        status: applied.relation?.relation_id ? "attached" : "registered",
         error: undefined,
       });
+      settleSuccessfulReferenceMutation(slotId, applied.workflow, [registered.source_asset_id]);
       argsRef.current.setStatus("V2 slot reference attached");
     } catch (error) {
       const message = error instanceof Error ? error.message : "V2 slot reference registration failed";
       argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachmentId, { status: "failed", error: message });
       argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, false, message);
       argsRef.current.setStatus(message);
+      return;
     }
+    argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, false);
   }
 
   async function replaceV2SlotWithLibraryEntity(slotId: string, entity: AssetLibraryEntitySummary) {
@@ -396,12 +464,12 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
     argsRef.current.setStatus(`Replacing ${slot.slot_type} from Asset Library...`);
     try {
+      const capture = captureSlotMutation(workflowId);
       const registered = await v2Api.registerLibraryReference(
         workflowId,
         buildSlotLibraryReferenceRegistration(slotId, entity.entity_id, null, slot.slot_type),
       );
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(registered.workflow, [registered.asset], registered.relation ? [registered.relation] : []);
+      await applyV2ReferenceArtifacts(workflowId, capture, registered.workflow, [registered.asset], registered.relation ? [registered.relation] : []);
       const assetId = registered.asset.asset_id;
       const versionId = registered.asset.version_id;
       if (!assetId || !versionId) {
@@ -428,11 +496,35 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
 
   async function removeV2SlotReference(slotId: string, reference: V2SlotReferenceRemoval) {
     const workflowId = activeWorkflowId();
+    const removedSourceAssetId = reference.asset_id ?? argsRef.current.v2SlotMicroEdit.state.draftsBySlotId[slotId]?.attachments.find((attachment) =>
+      attachment.relation_id === reference.relation_id ||
+      (reference.entity_id && attachment.library_entity_id === reference.entity_id)
+    )?.source_asset_id;
+    const removeLocalReference = () => {
+      if (reference.source === "library_entity" && reference.entity_id) {
+        argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "library_entity", entity_id: reference.entity_id, library_asset_id: reference.library_asset_id, relation_id: reference.relation_id });
+        return;
+      }
+      if (reference.source === "uploaded_asset" && reference.asset_id) {
+        argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "uploaded_asset", asset_id: reference.asset_id, relation_id: reference.relation_id });
+        return;
+      }
+      if (reference.asset_id) {
+        argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "reference_asset", asset_id: reference.asset_id, relation_id: reference.relation_id });
+      }
+    };
+    if (!reference.relation_id || !workflowId) {
+      removeLocalReference();
+      return;
+    }
     if (reference.relation_id && workflowId) {
+      argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
+      removeLocalReference();
       try {
+        const capture = captureSlotMutation(workflowId);
         const response = await v2Api.removeReference(workflowId, reference.relation_id);
-        if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-        await applyV2ReferenceArtifacts(response.workflow, response.assets ?? [], []);
+        const appliedWorkflow = await applyV2ReferenceArtifacts(workflowId, capture, response.workflow, response.assets ?? [], []);
+        settleSuccessfulReferenceMutation(slotId, appliedWorkflow, [], removedSourceAssetId ? [removedSourceAssetId] : []);
         await argsRef.current.syncV2Snapshot(workflowId);
         await loadV2SlotVersions(slotId);
       } catch (error) {
@@ -441,17 +533,8 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
         argsRef.current.setStatus(message);
         return;
       }
-    }
-    if (reference.source === "library_entity" && reference.entity_id) {
-      argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "library_entity", entity_id: reference.entity_id, library_asset_id: reference.library_asset_id, relation_id: reference.relation_id });
+      argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, false);
       return;
-    }
-    if (reference.source === "uploaded_asset" && reference.asset_id) {
-      argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "uploaded_asset", asset_id: reference.asset_id, relation_id: reference.relation_id });
-      return;
-    }
-    if (reference.asset_id) {
-      argsRef.current.v2SlotMicroEdit.removeReference(slotId, { source: "reference_asset", asset_id: reference.asset_id, relation_id: reference.relation_id });
     }
   }
 
@@ -460,12 +543,12 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     if (!slot) return;
     for (const uploadAssetId of draft.uploaded_asset_ids) {
       if (draft.attachments.some((attachment) => attachment.source_asset_id === uploadAssetId)) continue;
+      const capture = captureSlotMutation(workflowId);
       const registered = await v2Api.registerReferenceAsset(
         workflowId,
         buildSlotReferenceAssetRegistration(slotId, { source_type: "v1_upload", upload_asset_id: uploadAssetId }, slot.slot_type),
       );
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      const relation = await applyRegisteredV2SlotReference(workflowId, slotId, slot.slot_type, registered);
+      const { relation } = await applyRegisteredV2SlotReference(workflowId, slotId, slot.slot_type, registered, capture);
       argsRef.current.v2SlotMicroEdit.addAttachment(slotId, {
         id: `registered-upload:${slotId}:${uploadAssetId}`,
         source: "reference_asset",
@@ -474,25 +557,25 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
         preview_url: assetPreviewUrl(registered.asset),
         semantic_type: slot.slot_type,
         status: relation?.relation_id ? "attached" : "registered",
-      });
+      }, false);
     }
     for (const attachment of draft.attachments) {
       if (attachment.status === "failed") throw new Error(attachment.error || "V2 slot reference registration failed");
       if (attachment.relation_id && attachment.status === "attached") continue;
       if (attachment.source === "asset_library" && !attachment.source_asset_id && attachment.library_entity_id) {
+        const capture = captureSlotMutation(workflowId);
         const registered = await v2Api.registerLibraryReference(
           workflowId,
           buildSlotLibraryReferenceRegistration(slotId, attachment.library_entity_id, attachment.library_asset_id, attachment.semantic_type || slot.slot_type),
         );
-        if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
+        await requireFreshReferenceMutation(workflowId, capture);
         argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachment.id, {
           source_asset_id: registered.source_asset_id,
           preview_url: assetPreviewUrl(registered.asset) ?? attachment.preview_url,
           status: "registered",
           error: undefined,
         });
-        const relation = await applyRegisteredV2SlotReference(workflowId, slotId, attachment.semantic_type || slot.slot_type, registered);
-        if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
+        const { relation } = await applyRegisteredV2SlotReference(workflowId, slotId, attachment.semantic_type || slot.slot_type, registered, capture);
         argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachment.id, {
           source_asset_id: registered.source_asset_id,
           relation_id: relation?.relation_id,
@@ -502,15 +585,34 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
         continue;
       }
       if (!attachment.source_asset_id) continue;
+      const capture = captureSlotMutation(workflowId);
       const attached = await v2Api.attachReference(workflowId, buildSlotReferenceAttachRequest(slotId, attachment.source_asset_id, attachment.semantic_type || slot.slot_type));
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(attached.workflow, attached.assets ?? [], attached.relation ? [attached.relation] : []);
+      await applyV2ReferenceArtifacts(workflowId, capture, attached.workflow, attached.assets ?? [], attached.relation ? [attached.relation] : []);
       argsRef.current.v2SlotMicroEdit.updateAttachment(slotId, attachment.id, {
         relation_id: attached.relation?.relation_id,
         status: attached.relation?.relation_id ? "attached" : "registered",
         error: undefined,
       });
     }
+  }
+
+  function settleSuccessfulReferenceMutation(
+    slotId: string,
+    workflow: WorkflowV2 | null | undefined,
+    addedSourceAssetIds: string[] = [],
+    removedSourceAssetIds: string[] = [],
+  ) {
+    const slot = workflow?.slots.find((candidate) => candidate.slot_id === slotId) ?? v2SlotById(slotId);
+    if (!slot) return;
+    const removed = new Set(removedSourceAssetIds.filter(Boolean));
+    const explicitReferenceIds = Array.from(new Set([
+      ...(slot.explicit_reference_ids ?? []),
+      ...addedSourceAssetIds,
+    ].filter((assetId) => assetId && !removed.has(assetId))));
+    argsRef.current.v2SlotMicroEdit.markClean(slotId, {
+      ...slot,
+      explicit_reference_ids: explicitReferenceIds,
+    }, false, true);
   }
 
   async function loadV2SlotVersions(slotId: string) {
@@ -538,18 +640,21 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
     current.setStatus(`Saving ${flushes.length} V2 slot draft${flushes.length === 1 ? "" : "s"} before run...`);
 
     for (const flush of flushes) {
+      let savedSlot: WorkflowSlotV2 | undefined;
       current.v2SlotMicroEdit.setSubmitting(flush.slotId, true);
       try {
         if (flush.promptPatch) {
+          const capture = captureSlotMutation(workflowId);
           const nextWorkflow = await v2Api.updateSlotPrompt(workflowId, flush.slotId, flush.promptPatch);
-          if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-          await argsRef.current.applyWorkflowV2(nextWorkflow);
+          const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+          requireFreshSlotMutation(reconciled);
+          savedSlot = reconciled.workflow?.slots.find((slot) => slot.slot_id === flush.slotId);
         }
         if (flush.hasPendingReferences) {
           await ensureV2SlotDraftReferences(workflowId, flush.slotId, flush.draft);
           if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
         }
-        argsRef.current.v2SlotMicroEdit.markClean(flush.slotId);
+        argsRef.current.v2SlotMicroEdit.markClean(flush.slotId, savedSlot, Boolean(flush.promptPatch));
       } catch (error) {
         const message = error instanceof Error ? error.message : "V2 slot draft flush failed";
         argsRef.current.v2SlotMicroEdit.setSubmitting(flush.slotId, false, message);
@@ -578,7 +683,7 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
       return;
     }
     const draft = argsRef.current.v2SlotMicroEdit.state.draftsBySlotId[slotId] ?? {
-      prompt: slot.slot_prompt ?? "",
+      prompt: effectiveSlotPrompt(slot),
       negative_prompt: slot.negative_prompt ?? "",
       reference_asset_ids: [...(slot.explicit_reference_ids ?? [])],
       uploaded_asset_ids: [],
@@ -587,27 +692,30 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
       isSubmitting: false,
     };
     const request = buildSlotCandidateRegenerateRequest(draft, slot, sourceAction);
+    let savedSlot: WorkflowSlotV2 | undefined;
     argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
     argsRef.current.setStatus(sourceAction === "run_current_only" ? "Generating working candidate for current slot..." : `Generating working candidate for ${slot.slot_type}...`);
     try {
-      if (draft.dirty) {
+      const promptPersisted = slotDraftHasPromptChanges(draft);
+      if (promptPersisted) {
+        const capture = captureSlotMutation(workflowId);
         const nextWorkflow = await v2Api.updateSlotPrompt(workflowId, slotId, {
           slot_prompt: request.slot_prompt,
-          negative_prompt: request.negative_prompt || undefined,
+          negative_prompt: request.negative_prompt,
         });
-        if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-        await argsRef.current.applyWorkflowV2(nextWorkflow);
+        const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+        requireFreshSlotMutation(reconciled);
+        savedSlot = reconciled.workflow?.slots.find((candidate) => candidate.slot_id === slotId);
       }
       await ensureV2SlotDraftReferences(workflowId, slotId, draft);
+      const regenerateCapture = captureSlotMutation(workflowId);
       const response = await v2Api.regenerateSlot(workflowId, slotId);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      if (response.workflow) {
-        await argsRef.current.applyWorkflowV2(response.workflow, { refreshAssetsReason: false });
-      }
+      const regenerated = await applySlotMutationWorkflow(workflowId, regenerateCapture, response.workflow ?? null, { refreshAssetsReason: false });
+      requireFreshSlotMutation(regenerated);
       await argsRef.current.refreshV2AssetsAndRetryMissing(workflowId, response.workflow ? "slot-run-completed" : "slot-run-started", response.workflow ?? null);
       await argsRef.current.syncV2Snapshot(workflowId);
       await loadV2SlotVersions(slotId);
-      argsRef.current.v2SlotMicroEdit.markClean(slotId);
+      argsRef.current.v2SlotMicroEdit.markClean(slotId, regenerated.workflow?.slots.find((candidate) => candidate.slot_id === slotId) ?? savedSlot, promptPersisted);
       argsRef.current.setStatus(`${slot.slot_type} working candidate generated`);
     } catch (error) {
       const message = error instanceof Error ? error.message : "V2 slot candidate generation failed";
@@ -626,31 +734,36 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
       argsRef.current.setStatus("Select a concrete V2 slot before generating.");
       return;
     }
-    const nextPrompt = prompt.trim();
-    if (!nextPrompt) {
+    if (!prompt.trim()) {
       argsRef.current.setStatus("Prompt cannot be empty.");
       return;
     }
+    const nextPrompt = prompt;
+    const promptPersisted = nextPrompt !== effectiveSlotPrompt(slot);
     argsRef.current.v2SlotMicroEdit.updatePrompt(slotId, nextPrompt);
     argsRef.current.v2SlotMicroEdit.setSubmitting(slotId, true);
     argsRef.current.setStatus(`Generating working candidate for ${slot.slot_type}...`);
     try {
-      const nextWorkflow = await v2Api.updateSlotPrompt(workflowId, slotId, {
-        slot_prompt: nextPrompt,
-        negative_prompt: slot.negative_prompt ?? undefined,
-      });
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await argsRef.current.applyWorkflowV2(nextWorkflow);
-      await attachPromptReferencesToSlot(workflowId, slot, context);
-      const response = await v2Api.regenerateSlot(workflowId, slotId);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      if (response.workflow) {
-        await argsRef.current.applyWorkflowV2(response.workflow, { refreshAssetsReason: false });
+      let savedSlot: WorkflowSlotV2 | undefined;
+      if (promptPersisted) {
+        const capture = captureSlotMutation(workflowId);
+        const nextWorkflow = await v2Api.updateSlotPrompt(workflowId, slotId, {
+          slot_prompt: nextPrompt,
+          negative_prompt: slot.negative_prompt,
+        });
+        const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+        requireFreshSlotMutation(reconciled);
+        savedSlot = reconciled.workflow?.slots.find((candidate) => candidate.slot_id === slotId);
       }
+      await attachPromptReferencesToSlot(workflowId, slot, context);
+      const regenerateCapture = captureSlotMutation(workflowId);
+      const response = await v2Api.regenerateSlot(workflowId, slotId);
+      const regenerated = await applySlotMutationWorkflow(workflowId, regenerateCapture, response.workflow ?? null, { refreshAssetsReason: false });
+      requireFreshSlotMutation(regenerated);
       await argsRef.current.refreshV2AssetsAndRetryMissing(workflowId, response.workflow ? "slot-run-completed" : "slot-run-started", response.workflow ?? null);
       await argsRef.current.syncV2Snapshot(workflowId);
       await loadV2SlotVersions(slotId);
-      argsRef.current.v2SlotMicroEdit.markClean(slotId);
+      argsRef.current.v2SlotMicroEdit.markClean(slotId, regenerated.workflow?.slots.find((candidate) => candidate.slot_id === slotId) ?? savedSlot, promptPersisted);
       argsRef.current.setStatus(`${slot.slot_type} working candidate generated`);
     } catch (error) {
       const message = error instanceof Error ? error.message : "V2 slot candidate generation failed";
@@ -778,10 +891,14 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   async function discardV2WorkingVersion(slotId: string) {
     const workflowId = activeWorkflowId();
     if (!workflowId) return;
+    const capture = captureSlotMutation(workflowId);
     try {
       const nextWorkflow = await v2Api.discardWorkingVersion(workflowId, slotId);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await argsRef.current.applyWorkflowV2(nextWorkflow);
+      const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+      if (reconciled.stale) {
+        argsRef.current.setStatus(`${slotId} changed while discarding; latest state loaded`);
+        return;
+      }
       await loadV2SlotVersions(slotId);
       argsRef.current.setStatus(`${slotId} working version discarded`);
     } catch (error) {
@@ -792,10 +909,14 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   async function deleteV2SelectedSlotAsset(slotId: string) {
     const workflowId = activeWorkflowId();
     if (!workflowId) return;
+    const capture = captureSlotMutation(workflowId);
     try {
       const nextWorkflow = await v2Api.deleteSelectedSlotAsset(workflowId, slotId);
-      if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await argsRef.current.applyWorkflowV2(nextWorkflow);
+      const reconciled = await applySlotMutationWorkflow(workflowId, capture, nextWorkflow);
+      if (reconciled.stale) {
+        argsRef.current.setStatus(`${slotId} changed while deleting; latest state loaded`);
+        return;
+      }
       await loadV2SlotVersions(slotId);
       argsRef.current.setStatus(`${slotId} selected asset removed`);
     } catch (error) {
@@ -806,10 +927,11 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   async function attachV2Reference(request: V2ReferenceAttachRequest) {
     const workflowId = activeWorkflowId();
     if (!workflowId) return;
+    const capture = captureSlotMutation(workflowId);
     try {
       const response = await v2Api.attachReference(workflowId, request);
       if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(response.workflow, response.assets ?? [], response.relation ? [response.relation] : []);
+      await applyV2ReferenceArtifacts(workflowId, capture, response.workflow, response.assets ?? [], response.relation ? [response.relation] : []);
       argsRef.current.setStatus("V2 reference attached");
     } catch (error) {
       argsRef.current.setStatus(error instanceof Error ? error.message : "V2 reference attach failed");
@@ -819,10 +941,11 @@ export function useV2SlotOperations(args: V2SlotOperationsArgs) {
   async function removeV2Reference(relationId: string) {
     const workflowId = activeWorkflowId();
     if (!workflowId) return;
+    const capture = captureSlotMutation(workflowId);
     try {
       const response = await v2Api.removeReference(workflowId, relationId);
       if (!shouldApplyWorkflowScopedResult(workflowId, argsRef.current.activeWorkflowIdRef.current)) return;
-      await applyV2ReferenceArtifacts(response.workflow, response.assets ?? [], []);
+      await applyV2ReferenceArtifacts(workflowId, capture, response.workflow, response.assets ?? [], []);
       argsRef.current.setStatus("V2 reference removed");
     } catch (error) {
       argsRef.current.setStatus(error instanceof Error ? error.message : "V2 reference remove failed");

--- a/apps/web/src/features/workflow/v2/slots/v2SlotMutationWorkflowGuard.ts
+++ b/apps/web/src/features/workflow/v2/slots/v2SlotMutationWorkflowGuard.ts
@@ -1,0 +1,19 @@
+import type { WorkflowV2 } from "../../../../types-v2.ts";
+import type { V2WorkflowApplicationCapture } from "../../graph/v2WorkflowApplicationRevisionGuard.ts";
+
+export async function reconcileV2SlotMutationWorkflow(args: {
+  workflowId: string;
+  capture: V2WorkflowApplicationCapture;
+  activeWorkflowId: string | null;
+  isCurrentRevision: (capture: V2WorkflowApplicationCapture, currentActiveWorkflowId: string | null) => boolean;
+  returnedWorkflow?: WorkflowV2 | null;
+  applyWorkflowV2: (workflow: WorkflowV2) => Promise<void>;
+  refreshLatestWorkflow: () => Promise<WorkflowV2 | null>;
+}) {
+  if (args.isCurrentRevision(args.capture, args.activeWorkflowId)) {
+    if (args.returnedWorkflow) await args.applyWorkflowV2(args.returnedWorkflow);
+    return { stale: false as const, workflow: args.returnedWorkflow ?? null };
+  }
+  if (args.activeWorkflowId !== args.workflowId) return { stale: true as const, workflow: null };
+  return { stale: true as const, workflow: await args.refreshLatestWorkflow() };
+}

--- a/apps/web/src/features/workflow/v2/slots/v2SlotRebaseSnapshot.ts
+++ b/apps/web/src/features/workflow/v2/slots/v2SlotRebaseSnapshot.ts
@@ -1,0 +1,70 @@
+import type { WorkflowGraph, WorkflowNode } from "../../../../types.ts";
+import type { WorkflowItemV2, WorkflowSlotV2, WorkflowV2 } from "../../../../types-v2.ts";
+import { isWorkflowV2Graph } from "../../../../workflowSchema.ts";
+
+export type V2SlotRebaseSnapshot = {
+  slots: WorkflowSlotV2[];
+  archivedSlotIds: string[];
+  removedSlotIds: string[];
+  authoritative: boolean;
+};
+
+/** Builds an authoritative V2 slot snapshot from either API data or its graph adapter. */
+export function deriveV2SlotRebaseSnapshot(
+  source: WorkflowV2 | WorkflowGraph | null | undefined,
+  partialSlots: WorkflowSlotV2[] = [],
+): V2SlotRebaseSnapshot {
+  if (isWorkflowV2(source)) return snapshotFromItemsAndSlots(source.items, source.slots, true);
+  if (source && isWorkflowV2Graph(source)) {
+    const items = uniqueItemsById(source.nodes.flatMap(v2ItemsForGraphNode));
+    const slots = uniqueSlotsById(source.nodes.flatMap(v2SlotsForGraphNode));
+    return snapshotFromItemsAndSlots(items, slots, true);
+  }
+  return { slots: partialSlots, archivedSlotIds: [], removedSlotIds: [], authoritative: false };
+}
+
+function snapshotFromItemsAndSlots(items: WorkflowItemV2[], slots: WorkflowSlotV2[], authoritative: boolean): V2SlotRebaseSnapshot {
+  const archivedItemIds = new Set(items.filter((item) => item.lifecycle_state === "archived").map((item) => item.item_id));
+  return {
+    slots: slots.filter((slot) => !archivedItemIds.has(slot.item_id)),
+    archivedSlotIds: slots.filter((slot) => archivedItemIds.has(slot.item_id)).map((slot) => slot.slot_id),
+    removedSlotIds: [],
+    authoritative,
+  };
+}
+
+function v2ItemsForGraphNode(node: WorkflowNode): WorkflowItemV2[] {
+  return arrayFromNode(node, "v2_items").filter(isWorkflowItemV2);
+}
+
+function v2SlotsForGraphNode(node: WorkflowNode): WorkflowSlotV2[] {
+  const slots = arrayFromNode(node, "v2_slots").filter(isWorkflowSlotV2);
+  return slots.length ? slots : v2ItemsForGraphNode(node).flatMap((item) => Array.isArray(item.slots) ? item.slots.filter(isWorkflowSlotV2) : []);
+}
+
+function arrayFromNode(node: WorkflowNode, key: "v2_items" | "v2_slots"): unknown[] {
+  const input = node.input_context?.[key];
+  if (Array.isArray(input)) return input;
+  const metadata = node.metadata?.[key];
+  return Array.isArray(metadata) ? metadata : [];
+}
+
+function uniqueItemsById(values: WorkflowItemV2[]): WorkflowItemV2[] {
+  return [...new Map(values.map((value) => [value.item_id, value])).values()];
+}
+
+function uniqueSlotsById(values: WorkflowSlotV2[]): WorkflowSlotV2[] {
+  return [...new Map(values.map((value) => [value.slot_id, value])).values()];
+}
+
+function isWorkflowV2(value: WorkflowV2 | WorkflowGraph | null | undefined): value is WorkflowV2 {
+  return Boolean(value && "items" in value && Array.isArray(value.items) && "slots" in value && Array.isArray(value.slots));
+}
+
+function isWorkflowItemV2(value: unknown): value is WorkflowItemV2 {
+  return Boolean(value && typeof value === "object" && typeof (value as { item_id?: unknown }).item_id === "string");
+}
+
+function isWorkflowSlotV2(value: unknown): value is WorkflowSlotV2 {
+  return Boolean(value && typeof value === "object" && typeof (value as { slot_id?: unknown }).slot_id === "string");
+}

--- a/apps/web/src/features/workflow/workbench/WorkflowWorkbenchSurface.tsx
+++ b/apps/web/src/features/workflow/workbench/WorkflowWorkbenchSurface.tsx
@@ -45,6 +45,7 @@ import { WorkflowWorkbenchV2Section } from "./WorkflowWorkbenchV2Section.tsx";
 import { WorkflowWorkbenchPromptSection } from "./WorkflowWorkbenchPromptSection.tsx";
 import { WorkflowWorkbenchAssetsSection } from "./WorkflowWorkbenchAssetsSection.tsx";
 import { WorkflowWorkbenchDebugSection } from "./WorkflowWorkbenchDebugSection.tsx";
+import type { SlotPromptSaveResult } from "../v2/slots/slotPromptEditorState.ts";
 
 type StateSetter<T> = (value: T | ((current: T) => T)) => void;
 type MaybePromise<T = unknown> = T | Promise<T>;
@@ -157,7 +158,7 @@ export type WorkflowWorkbenchSurfaceActions = {
   deleteV2FinalTimelineClip: (clipId: string) => MaybePromise;
   runSelectedV2Slot: (slotId?: string) => MaybePromise;
   loadV2SlotVersions: (slotId: string) => MaybePromise;
-  saveV2SlotPrompt: (slotId: string, prompt: string, negativePrompt?: string) => MaybePromise;
+  saveV2SlotPrompt: (slotId: string, prompt: string, negativePrompt?: string) => MaybePromise<SlotPromptSaveResult>;
   selectV2SlotVersion: (slotId: string, versionId: string) => MaybePromise;
   discardV2WorkingVersion: (slotId: string) => MaybePromise;
   deleteV2SelectedSlotAsset: (slotId: string) => MaybePromise;

--- a/apps/web/src/icons.tsx
+++ b/apps/web/src/icons.tsx
@@ -43,6 +43,14 @@ export function ChevronDownIcon(props: IconProps) {
   );
 }
 
+export function ChevronUpIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path d="m7 14.5 5-5 5 5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function CloseIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -3,13 +3,23 @@ import type { CSSProperties } from "react";
 import { useApp } from "../AppContextValue";
 import { SectionTitle } from "../components/Cards";
 import { HomePromptComposer, type HomePromptGenerateContext } from "../components/HomePromptComposer";
+import { PlanningErrorNotice } from "../components/PlanningErrorNotice";
 import { demoProjects, images, imageSrc } from "../data";
 import { PlayIcon } from "../icons";
-import type { RouteName } from "../types";
+import type { FrontDeskMessage, RouteName } from "../types";
 import type { V2InputAssetUploadItem } from "../types-v2.ts";
+import type { PlanningFailureState } from "./homeWorkflowPlanning";
+
+type PendingPlanningRequest = {
+  prompt: string;
+  context: HomePromptGenerateContext;
+  history: FrontDeskMessage[];
+};
 
 export function HomePage({ navigate }: { navigate: (route: RouteName) => void }) {
   const [modalOpen, setModalOpen] = useState(false);
+  const [planningError, setPlanningError] = useState<PlanningFailureState | null>(null);
+  const [pendingPlanningRequest, setPendingPlanningRequest] = useState<PendingPlanningRequest | null>(null);
   const { messages, promptLibraryEntities, setMessages, setWorkflow } = useApp();
 
   const discoverCards: Array<[string, string, number]> = [
@@ -32,15 +42,17 @@ export function HomePage({ navigate }: { navigate: (route: RouteName) => void })
     return response.assets;
   }
 
-  async function generate(prompt: string, context: HomePromptGenerateContext = {}) {
-    const nextMessages = [...messages, { role: "user" as const, content: prompt }];
-    setMessages(nextMessages);
+  async function generate(prompt: string, context: HomePromptGenerateContext = {}, retry = false) {
+    const history = retry && pendingPlanningRequest ? pendingPlanningRequest.history : messages;
+    const nextMessages = retry ? messages : [...messages, { role: "user" as const, content: prompt }];
+    if (!retry) setMessages(nextMessages);
+    setPlanningError(null);
 
     try {
       const { planHomeWorkflow } = await import("./homeWorkflowPlanning");
       const response = await planHomeWorkflow({
         prompt,
-        history: messages,
+        history,
         inputAssets: [...(context.input_asset_locators ?? []), ...(context.asset_locators ?? [])],
         libraryEntities: promptLibraryEntities,
       });
@@ -51,16 +63,16 @@ export function HomePage({ navigate }: { navigate: (route: RouteName) => void })
       } else if (!response.shouldStartWorkflow) {
         navigate("workflow");
       }
-    } catch {
-      setMessages([
-        ...nextMessages,
-        {
-          role: "assistant",
-          content: "Backend is not available yet, so I opened the demo workflow canvas.",
-        },
-      ]);
-      navigate("workflow");
+      setPendingPlanningRequest(null);
+    } catch (error) {
+      const { planningFailureState } = await import("./homeWorkflowPlanning");
+      setPlanningError(planningFailureState(error));
+      setPendingPlanningRequest({ prompt, context, history });
     }
+  }
+
+  function retryPlanning() {
+    if (pendingPlanningRequest) void generate(pendingPlanningRequest.prompt, pendingPlanningRequest.context, true);
   }
 
   return (
@@ -73,6 +85,7 @@ export function HomePage({ navigate }: { navigate: (route: RouteName) => void })
             onGenerate={generate}
             onUploadInputAsset={uploadPromptInputAsset}
           />
+          {planningError ? <PlanningErrorNotice error={planningError} onRetry={retryPlanning} /> : null}
           <div className="mode-row">
             {["Video", "Image", "Storyboard", "Character", "Scene"].map((mode, index) => (
               <button key={mode} className={`mode ${index === 0 ? "is-active" : ""}`}>

--- a/apps/web/src/pages/homeWorkflowPlanning.ts
+++ b/apps/web/src/pages/homeWorkflowPlanning.ts
@@ -1,4 +1,4 @@
-import { v2Api } from "../api/v2Client";
+import { isNetworkError, isV2ApiError, v2Api } from "../api/v2Client";
 import { buildV2PlanFromChatRequest } from "../features/workflow/copilot/copilotRequestBuilders";
 import type { AssetLibraryEntitySummary, FrontDeskMessage, WorkflowGraph } from "../types";
 import { workflowV2ToWorkflowGraph } from "../workflow-v2/pageAdapter";
@@ -16,6 +16,14 @@ export type HomeWorkflowPlanningResult = {
   shouldStartWorkflow: boolean;
 };
 
+export type PlanningFailureState = {
+  shouldNavigate: false;
+  message: string;
+  stage?: string;
+  violations: unknown[];
+  suggestedActions: Array<Record<string, unknown>>;
+};
+
 export async function planHomeWorkflow(args: HomeWorkflowPlanningArgs): Promise<HomeWorkflowPlanningResult> {
   const response = await v2Api.planFromChat(buildV2PlanFromChatRequest({
     message: args.prompt,
@@ -30,4 +38,47 @@ export async function planHomeWorkflow(args: HomeWorkflowPlanningArgs): Promise<
     workflow: response.workflow ? workflowV2ToWorkflowGraph(response.workflow) : null,
     shouldStartWorkflow: response.front_desk.should_start_workflow,
   };
+}
+
+export function planningFailureState(error: unknown): PlanningFailureState {
+  if (isNetworkError(error)) {
+    return {
+      shouldNavigate: false,
+      message: "Backend is not available yet. Check the connection and try again.",
+      violations: [],
+      suggestedActions: [],
+    };
+  }
+  if (isV2ApiError(error)) {
+    return {
+      shouldNavigate: false,
+      message: error.message,
+      stage: error.stage,
+      violations: error.violations,
+      suggestedActions: error.suggestedActions,
+    };
+  }
+  if (hasHttpErrorShape(error)) {
+    return {
+      shouldNavigate: false,
+      message: error.message,
+      violations: [],
+      suggestedActions: [],
+    };
+  }
+  return {
+    shouldNavigate: false,
+    message: error instanceof Error ? error.message : "Planning could not be completed. Try again.",
+    violations: [],
+    suggestedActions: [],
+  };
+}
+
+function hasHttpErrorShape(value: unknown): value is { status: number; message: string } {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && typeof (value as { status?: unknown }).status === "number"
+    && typeof (value as { message?: unknown }).message === "string",
+  );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -63,6 +63,138 @@ body::before {
   content: "";
 }
 
+.v2-screenplay-drawer-backdrop {
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(32, 34, 53, 0.24);
+}
+
+.v2-screenplay-drawer {
+  position: relative;
+  display: grid;
+  width: min(760px, 92vw);
+  height: 100dvh;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  border-left: 1px solid rgba(108, 93, 171, 0.2);
+  background: rgba(247, 249, 253, 0.98);
+  box-shadow: -18px 0 50px rgba(32, 34, 53, 0.2);
+}
+
+.v2-screenplay-drawer__header,
+.v2-screenplay-drawer__footer,
+.v2-screenplay-section-heading,
+.v2-screenplay-item-heading,
+.v2-screenplay-tabs,
+.v2-screenplay-conflict > div,
+.v2-screenplay-discard-confirmation > dialog > div,
+.v2-screenplay-version-heading {
+  display: flex;
+  align-items: center;
+}
+
+.v2-screenplay-drawer__top { min-width: 0; }
+
+.v2-screenplay-drawer__header {
+  z-index: 2;
+  justify-content: space-between;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--stroke-dark);
+  background: rgba(247, 249, 253, 0.98);
+}
+
+.v2-screenplay-drawer__header > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.v2-screenplay-drawer__header p,
+.v2-screenplay-history p,
+.v2-screenplay-conflict p,
+.v2-screenplay-discard-confirmation p { margin: 0; color: var(--muted); font-size: 13px; }
+.v2-screenplay-drawer__header p { line-height: 1.2; }
+.v2-screenplay-drawer h2, .v2-screenplay-section h3, .v2-screenplay-history h3, .v2-screenplay-section h4, .v2-screenplay-dialogue h5 { margin: 0; letter-spacing: 0; }
+.v2-screenplay-drawer h2 { font-size: 20px; line-height: 1.2; }
+.v2-screenplay-drawer h2:focus { outline: 2px solid var(--iris); outline-offset: 3px; }
+
+.v2-screenplay-icon-button,
+.v2-screenplay-icon-actions button {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--stroke-dark);
+  border-radius: 4px;
+  background: var(--glass-button);
+}
+.v2-screenplay-icon-button svg, .v2-screenplay-icon-actions svg, .v2-screenplay-tabs svg, .v2-screenplay-confirm svg, .v2-screenplay-add svg, .v2-screenplay-version-heading svg { width: 16px; height: 16px; }
+.v2-screenplay-icon-actions { display: flex; gap: 5px; }
+.v2-screenplay-icon-actions button:disabled, .v2-screenplay-add:disabled { cursor: not-allowed; opacity: .45; }
+
+.v2-screenplay-tabs { gap: 3px; padding: 10px 22px; border-bottom: 1px solid var(--stroke-dark); }
+.v2-screenplay-tabs button { display: inline-flex; gap: 7px; align-items: center; padding: 8px 11px; border-radius: 4px; background: transparent; color: var(--muted); font-size: 13px; }
+.v2-screenplay-tabs button[aria-selected="true"] { background: rgba(108, 93, 171, .13); color: var(--ink); font-weight: 700; }
+
+.v2-screenplay-drawer__body { min-height: 0; overflow: auto; padding: 18px 22px 30px; }
+.v2-screenplay-drawer__footer { position: sticky; bottom: 0; justify-content: space-between; gap: 14px; padding: 14px 22px; border-top: 1px solid var(--stroke-dark); background: rgba(247, 249, 253, .98); color: var(--muted); font-size: 13px; }
+.v2-screenplay-confirm, .v2-screenplay-secondary-action, .v2-screenplay-danger-action, .v2-screenplay-add { display: inline-flex; align-items: center; justify-content: center; gap: 7px; border-radius: 4px; font-weight: 700; }
+.v2-screenplay-confirm { padding: 9px 13px; background: var(--iris); color: white; }
+.v2-screenplay-confirm:disabled { cursor: not-allowed; opacity: .55; }
+.v2-screenplay-secondary-action, .v2-screenplay-danger-action { padding: 8px 10px; border: 1px solid var(--stroke-dark); background: var(--surface-strong); font-size: 13px; }
+.v2-screenplay-danger-action { border-color: rgba(171, 71, 87, .36); color: #9a3043; }
+.v2-screenplay-add { padding: 6px 8px; background: transparent; color: var(--iris); font-size: 13px; }
+
+.v2-screenplay-section { padding: 18px 0; border-bottom: 1px solid var(--stroke-dark); }
+.v2-screenplay-section-heading { justify-content: space-between; gap: 12px; margin-bottom: 13px; }
+.v2-screenplay-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 11px; }
+.v2-screenplay-fields--compact { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.v2-screenplay-field { display: grid; gap: 5px; min-width: 0; color: var(--muted); font-size: 12px; font-weight: 700; }
+.v2-screenplay-field input, .v2-screenplay-field textarea, .v2-screenplay-field select { width: 100%; min-width: 0; border: 1px solid rgba(108, 93, 171, .22); border-radius: 4px; background: rgba(255, 255, 255, .72); padding: 8px; color: var(--ink); font-weight: 400; }
+.v2-screenplay-field textarea { min-height: 66px; resize: vertical; }
+.v2-screenplay-field select[multiple] { min-height: 74px; }
+.v2-screenplay-field em { color: #a42e40; font-size: 12px; font-style: normal; }
+.v2-screenplay-entity, .v2-screenplay-scene, .v2-screenplay-shot, .v2-screenplay-dialogue-line, .v2-screenplay-version { padding: 13px 0; border-top: 1px solid rgba(108, 93, 171, .12); }
+.v2-screenplay-item-heading { justify-content: space-between; gap: 12px; margin-bottom: 10px; font-size: 13px; }
+.v2-screenplay-shots, .v2-screenplay-dialogue, .v2-screenplay-product-beats { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(108, 93, 171, .17); }
+.v2-screenplay-beat { padding: 10px 0; border-top: 1px solid rgba(108, 93, 171, .12); }
+.v2-screenplay-dialogue h5 { font-size: 13px; }
+.v2-screenplay-empty, .v2-screenplay-status, .v2-screenplay-hint { margin: 10px 0; color: var(--muted); font-size: 13px; }
+.v2-screenplay-empty em { display: block; margin-top: 5px; color: #a42e40; font-style: normal; }
+.v2-screenplay-validation-summary { margin: 0 0 12px; padding: 12px; border: 1px solid rgba(171, 71, 87, .36); border-radius: 4px; background: rgba(255, 236, 238, .66); color: #8d2335; font-size: 13px; }
+.v2-screenplay-validation-summary ul { margin: 8px 0 0; padding-left: 20px; }
+.v2-screenplay-validation-summary li + li { margin-top: 4px; }
+.v2-screenplay-validation-summary code { overflow-wrap: anywhere; }
+
+.v2-screenplay-conflict, .v2-screenplay-request-error { margin: 0 0 12px; padding: 12px; border: 1px solid rgba(180, 126, 48, .38); border-radius: 4px; background: rgba(254, 233, 161, .34); font-size: 13px; }
+.v2-screenplay-request-error { border-color: rgba(171, 71, 87, .36); background: rgba(255, 236, 238, .66); }
+.v2-screenplay-request-error p { margin: 6px 0; }
+.v2-screenplay-conflict > div { flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.v2-screenplay-history { max-width: 100%; }
+.v2-screenplay-version { padding: 15px 0; }
+.v2-screenplay-version.is-selected { border-left: 3px solid var(--iris); padding-left: 10px; }
+.v2-screenplay-version-heading { gap: 9px; }
+.v2-screenplay-version-heading > div { display: grid; gap: 2px; }
+.v2-screenplay-version-heading span { color: var(--iris); font-size: 12px; font-weight: 700; }
+.v2-screenplay-version dl { display: grid; gap: 7px; margin: 12px 0; }
+.v2-screenplay-version dl div { display: grid; grid-template-columns: 72px minmax(0, 1fr); gap: 8px; }
+.v2-screenplay-version dt { color: var(--muted); font-size: 12px; }
+.v2-screenplay-version dd { min-width: 0; margin: 0; font-size: 13px; overflow-wrap: anywhere; }
+
+.v2-screenplay-discard-confirmation { position: absolute; z-index: 4; inset: 0; display: grid; place-items: center; padding: 22px; background: rgba(32, 34, 53, .38); }
+.v2-screenplay-discard-confirmation > dialog { max-width: 410px; margin: 0; padding: 18px; border: 0; border-radius: 4px; background: #fff; box-shadow: var(--shadow-soft); }
+.v2-screenplay-discard-confirmation h3 { margin: 0 0 7px; font-size: 16px; }
+.v2-screenplay-discard-confirmation > dialog > div { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+
+@media (max-width: 700px) {
+  .v2-screenplay-drawer { width: 100%; border-left: 0; }
+  .v2-screenplay-fields, .v2-screenplay-fields--compact { grid-template-columns: 1fr; }
+  .v2-screenplay-drawer__footer { align-items: flex-end; }
+  .v2-screenplay-confirm { flex: 0 0 auto; }
+}
+
 button,
 input,
 textarea,
@@ -4169,6 +4301,7 @@ button.workflow-card-preview:focus-visible {
   place-items: initial;
   text-align: left;
   overscroll-behavior: contain;
+  cursor: pointer;
 }
 
 .workflow-card-preview.v2-script-text-card pre {
@@ -7157,36 +7290,6 @@ button.canvas-entity-media {
   font-style: normal;
   font-weight: 900;
   padding: 4px 7px;
-}
-
-.v2-slot-outdated-hint {
-  display: grid;
-  min-width: 0;
-  gap: 4px;
-  border: 1px solid rgba(96, 126, 172, 0.18);
-  border-radius: 10px;
-  background: rgba(244, 248, 252, 0.76);
-  color: rgba(47, 57, 83, 0.86);
-  padding: 8px 9px;
-}
-
-.v2-slot-outdated-hint strong,
-.v2-slot-outdated-hint span,
-.v2-slot-outdated-hint small {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.v2-slot-outdated-hint strong {
-  font-size: 11px;
-  font-weight: 900;
-}
-
-.v2-slot-outdated-hint span,
-.v2-slot-outdated-hint small {
-  color: rgba(74, 82, 111, 0.72);
-  font-size: 10px;
-  font-weight: 800;
 }
 
 .v2-slot-version,

--- a/apps/web/src/types-v2.ts
+++ b/apps/web/src/types-v2.ts
@@ -127,6 +127,8 @@ export interface WorkflowSlotV2 {
   required: boolean;
   status: WorkflowSlotStatusV2 | string;
   slot_prompt?: string;
+  system_suggested_prompt?: string;
+  user_prompt?: string;
   negative_prompt?: string;
   media_prompt_asset_ids?: string[];
   implicit_reference_ids?: string[];
@@ -146,6 +148,17 @@ export interface WorkflowSlotV2 {
   negative_constraints?: string | null;
   warnings?: Array<{ code?: string; message?: string; [key: string]: unknown }>;
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Returns the editable prompt layer while preserving user-authored whitespace.
+ * Whitespace is normalized only to decide whether a layer is present.
+ */
+export function effectiveSlotPrompt(slot: Pick<WorkflowSlotV2, "slot_prompt" | "system_suggested_prompt" | "user_prompt">): string {
+  for (const prompt of [slot.user_prompt, slot.system_suggested_prompt, slot.slot_prompt]) {
+    if (typeof prompt === "string" && prompt.trim()) return prompt;
+  }
+  return "";
 }
 
 export interface AssetVersionV2 {
@@ -591,6 +604,12 @@ export interface V2PlanFromChatRequest {
 export interface V2PlanFromChatResponse {
   front_desk: FrontDeskResponse;
   workflow: WorkflowV2 | null;
+  normalized_v2_request?: Record<string, unknown> | null;
+  status?: string | null;
+  error_code?: string | null;
+  message?: string | null;
+  details: Record<string, unknown>;
+  suggested_actions: Array<Record<string, unknown>>;
 }
 
 export interface WorkflowV2RunResponse {
@@ -782,4 +801,231 @@ export interface V2WorkflowErrorDetail {
   code?: string;
   message?: string;
   [key: string]: unknown;
+}
+
+export type V2ScriptSourceAction = "initial_planning" | "script_editor_confirm" | "agent_chat_edit";
+
+export type V2ScriptAspectRatio = "16:9" | "9:16" | "4:3" | "3:4" | "1:1" | "21:9";
+
+export interface V2ScriptDialogueLine {
+  dialogue_id: string;
+  character_id: string;
+  performance_cue: string | null;
+  text: string;
+}
+
+export interface V2ScriptShot {
+  shot_id: string;
+  scene_id: string;
+  shot_index: number;
+  product_ids: string[];
+  character_ids: string[];
+  scene_ids: string[];
+  reference_item_ids: string[];
+  description: string;
+  dialogue: V2ScriptDialogueLine[];
+  narration: string | null;
+  visual_prompt: string;
+  duration_seconds: number;
+}
+
+export interface V2ScriptScene {
+  scene_id: string;
+  title: string;
+  description: string;
+  location_id: string | null;
+  shot_ids: string[];
+  duration_seconds: number;
+  location_type: string | null;
+  time_of_day: string | null;
+  setting_type: "interior" | "exterior" | null;
+}
+
+export interface V2ScriptCharacter {
+  character_id: string;
+  display_name: string;
+  description: string;
+  role: string;
+  visual_notes: string;
+  gender: string | null;
+}
+
+export interface V2ScriptLocation {
+  location_id: string;
+  display_name: string;
+  description: string;
+  visual_notes: string;
+  location_type: string | null;
+  time_of_day: string | null;
+  setting_type: "interior" | "exterior" | null;
+}
+
+export interface V2ScriptPlan {
+  script_plan_version: 2;
+  script_brief_id: string;
+  script_version_id: string;
+  language: string;
+  script_title: string;
+  script_text: string;
+  scenes: V2ScriptScene[];
+  shots: V2ScriptShot[];
+  characters: V2ScriptCharacter[];
+  locations: V2ScriptLocation[];
+  product_beats: string[];
+  tone: string;
+  visual_style: string;
+  duration_seconds: number;
+  aspect_ratio: V2ScriptAspectRatio;
+  materializer_mode: "real" | "mock";
+  model_id: string | null;
+  selected_skill_ids: string[];
+  selected_skill_paths: string[];
+  skill_context_warnings: Array<Record<string, unknown>>;
+  quality_notes: string[];
+  materializer_version: string | null;
+  metadata: Record<string, unknown>;
+  warnings: Array<Record<string, unknown>>;
+}
+
+export interface V2EditableScriptDialogue {
+  dialogue_id?: string | null;
+  client_key?: string | null;
+  character_id: string;
+  performance_cue?: string | null;
+  text: string;
+}
+
+export interface V2EditableScriptShot {
+  shot_id?: string | null;
+  client_key?: string | null;
+  product_ids?: string[];
+  character_ids?: string[];
+  scene_ids?: string[];
+  description: string;
+  dialogue?: V2EditableScriptDialogue[];
+  narration?: string | null;
+  visual_prompt: string;
+  duration_seconds: number;
+}
+
+export interface V2EditableScriptScene {
+  scene_id?: string | null;
+  client_key?: string | null;
+  title: string;
+  description: string;
+  location_id?: string | null;
+  location_type?: string | null;
+  time_of_day?: string | null;
+  setting_type?: "interior" | "exterior" | null;
+  shots: V2EditableScriptShot[];
+}
+
+export interface V2EditableScriptCharacter {
+  character_id?: string | null;
+  client_key?: string | null;
+  display_name: string;
+  description: string;
+  role: string;
+  visual_notes: string;
+  gender?: string | null;
+}
+
+export interface V2EditableScriptLocation {
+  location_id?: string | null;
+  client_key?: string | null;
+  display_name: string;
+  description: string;
+  visual_notes: string;
+  location_type?: string | null;
+  time_of_day?: string | null;
+  setting_type?: "interior" | "exterior" | null;
+}
+
+export interface V2EditableScriptDocument {
+  script_title: string;
+  language: string;
+  characters?: V2EditableScriptCharacter[];
+  locations?: V2EditableScriptLocation[];
+  scenes: V2EditableScriptScene[];
+  product_beats?: string[];
+  tone: string;
+  visual_style: string;
+  aspect_ratio: V2ScriptAspectRatio;
+}
+
+export interface V2ScriptConfirmRequest {
+  base_script_version_id: string;
+  document: V2EditableScriptDocument;
+  source_action?: "script_editor_confirm" | "agent_chat_edit";
+}
+
+export interface V2ScriptSelectVersionRequest {
+  base_selected_script_version_id: string;
+}
+
+export interface V2ScriptStructuralDiff {
+  added_character_ids: string[];
+  archived_character_ids: string[];
+  reactivated_character_ids: string[];
+  updated_character_ids: string[];
+  added_location_ids: string[];
+  archived_location_ids: string[];
+  reactivated_location_ids: string[];
+  updated_location_ids: string[];
+  added_scene_ids: string[];
+  archived_scene_ids: string[];
+  reactivated_scene_ids: string[];
+  updated_scene_ids: string[];
+  added_shot_ids: string[];
+  archived_shot_ids: string[];
+  reactivated_shot_ids: string[];
+  updated_shot_ids: string[];
+  added_dialogue_ids: string[];
+  archived_dialogue_ids: string[];
+  updated_dialogue_ids: string[];
+  order_changed: boolean;
+}
+
+export interface V2LinkedContextSummary {
+  updated_node_ids: string[];
+  updated_item_ids: string[];
+  updated_slot_ids: string[];
+  updated_fields: string[];
+  selected_asset_versions_changed: false;
+  provider_execution_started: false;
+  refresh: string[];
+}
+
+export interface V2ScriptReadResponse {
+  workflow_id: string;
+  selected_script_version_id: string;
+  script: V2ScriptPlan;
+  events_cursor: number;
+}
+
+export interface V2ScriptConfirmResponse extends V2ScriptReadResponse {
+  structural_diff: V2ScriptStructuralDiff;
+  linked_context: V2LinkedContextSummary;
+}
+
+export interface V2ScriptVersionSummary {
+  script_version_id: string;
+  parent_script_version_id: string | null;
+  created_at: string;
+  source_action: V2ScriptSourceAction;
+  script_title: string;
+  content_hash: string;
+  structural_diff_summary: Record<string, unknown>;
+}
+
+export interface V2ScriptVersionListResponse {
+  workflow_id: string;
+  selected_script_version_id: string;
+  versions: V2ScriptVersionSummary[];
+  events_cursor: number;
+}
+
+export interface V2ScriptSelectVersionResponse extends V2ScriptReadResponse {
+  structural_diff: V2ScriptStructuralDiff;
+  linked_context: V2LinkedContextSummary;
 }

--- a/apps/web/src/workflow-v2/lifecycle.ts
+++ b/apps/web/src/workflow-v2/lifecycle.ts
@@ -1,24 +1,6 @@
 import type { WorkflowMediaTypeV2 } from "../types-v2.ts";
 import { freeAbsorbTargetsForMedia } from "./agentRouting.ts";
 
-export type V2FreshnessHint = {
-  reference_outdated?: boolean;
-  linked_source_has_new_version?: boolean;
-  outdated_source_asset_id?: string;
-  latest_source_asset_id?: string;
-  reference_target_archived?: boolean;
-};
-
-export function shouldAutoRegenerateForFreshnessHint(_hint: V2FreshnessHint) {
-  return false;
-}
-
-export function referenceFreshnessLabel(hint: V2FreshnessHint) {
-  if (hint.reference_target_archived) return "Reference target archived";
-  if (hint.linked_source_has_new_version || hint.reference_outdated) return "Linked source has a newer version";
-  return "Reference is current";
-}
-
 export function absorbTargetsForFreeAsset(mediaType: WorkflowMediaTypeV2) {
   return freeAbsorbTargetsForMedia(mediaType);
 }

--- a/apps/web/src/workflow-v2/runtime.ts
+++ b/apps/web/src/workflow-v2/runtime.ts
@@ -9,6 +9,17 @@ import type {
 export type V2RuntimeConnectionState = "connecting" | "connected" | "reconnecting" | "degraded_polling" | "disconnected";
 export type V2ConnectionState = V2RuntimeConnectionState;
 
+export const V2_SYNCHRONIZATION_EVENT_TYPES = new Set([
+  "script_version_created",
+  "script_selected_version_updated",
+  "workflow_structure_updated",
+  "linked_context_updated",
+]);
+
+export function isV2SynchronizationEvent(eventType: string): boolean {
+  return V2_SYNCHRONIZATION_EVENT_TYPES.has(eventType);
+}
+
 export interface WorkflowRuntimeStoreV2 {
   connectionState: V2RuntimeConnectionState;
   lastEventSeq: number;
@@ -240,6 +251,17 @@ export function applyWorkflowRuntimeEventV2(current: WorkflowRuntimeStoreV2, eve
     refreshSlotVersions: false,
     refreshResolvedInputs: false,
   };
+  if (isV2SynchronizationEvent(event.event_type)) {
+    const refresh = refreshHints(event);
+    return {
+      ...next,
+      refreshWorkflow:
+        event.event_type === "script_selected_version_updated" ||
+        event.event_type === "workflow_structure_updated" ||
+        (event.event_type === "linked_context_updated" &&
+          refresh.some((hint) => hint === "workflow" || hint === "slot_prompts" || hint === "references")),
+    };
+  }
   const slotId = event.slot_id;
   const itemId = event.item_id ?? (slotId ? next.slotItemIds[slotId] : undefined);
   const nodeId = event.node_id ?? (slotId ? next.slotNodeIds[slotId] : undefined);
@@ -467,7 +489,6 @@ export function applyWorkflowRuntimeEventV2(current: WorkflowRuntimeStoreV2, eve
     event.event_type === "prompt_updated" ||
     event.event_type === "item_prompt_updated" ||
     event.event_type === "slot_prompt_updated" ||
-    event.event_type === "slot_marked_stale" ||
     event.event_type === "reference_attached" ||
     event.event_type === "reference_removed" ||
     event.event_type === "slot_working_version_discarded" ||
@@ -475,10 +496,6 @@ export function applyWorkflowRuntimeEventV2(current: WorkflowRuntimeStoreV2, eve
     event.event_type === "asset_history_updated" ||
     event.event_type === "workflow_updated" ||
     event.event_type === "resolved_inputs_updated" ||
-    event.event_type === "slot_outdated_hint_added" ||
-    event.event_type === "item_outdated_hint_added" ||
-    event.event_type === "node_outdated_hint_added" ||
-    event.event_type === "slot_outdated_hint_cleared" ||
     event.event_type === "storyboard_summary_refined"
   ) {
     const refresh = refreshHints(event);

--- a/apps/web/src/workflow-v2/selectors.ts
+++ b/apps/web/src/workflow-v2/selectors.ts
@@ -1,6 +1,5 @@
 import type {
   AssetVersionV2,
-  OutdatedSourceV2,
   ProviderTaskStatusV2,
   RuntimeRecordV2,
   SlotFunctionalCardViewModel,
@@ -11,6 +10,7 @@ import type {
   WorkflowSlotV2,
   WorkflowV2,
 } from "../types-v2.ts";
+import { effectiveSlotPrompt } from "../types-v2.ts";
 import { chooseMoreCompleteV2Asset } from "./assets.ts";
 
 export function assetVersionByAssetId(workflow: Pick<WorkflowV2, "asset_versions">) {
@@ -161,34 +161,6 @@ export function dedupeSlotVersionAssets(versions: AssetVersionV2[]) {
   return result;
 }
 
-export type V2OutdatedHintView = {
-  active: boolean;
-  label: string;
-  sources: OutdatedSourceV2[];
-};
-
-export function outdatedHintForSlot(slot: WorkflowSlotV2 | undefined): V2OutdatedHintView {
-  if (!slot) return { active: false, label: "", sources: [] };
-  return outdatedHintFromMetadata(slot.metadata);
-}
-
-export function outdatedHintFromMetadata(metadata: Record<string, unknown> | undefined): V2OutdatedHintView {
-  const active = Boolean(
-    metadata?.outdated_hint ||
-      metadata?.is_outdated ||
-      metadata?.outdated ||
-      metadata?.stale_hint ||
-      metadata?.reference_updated,
-  );
-  const sources = outdatedSourcesFromMetadata(metadata);
-  if (!active && !sources.length) return { active: false, label: "", sources: [] };
-  return {
-    active: true,
-    label: firstString(metadata?.outdated_label, metadata?.outdated_hint_label, metadata?.stale_label) || "Reference updated",
-    sources,
-  };
-}
-
 export function isIdOnlyAssetVersion(asset?: AssetVersionV2 | null) {
   return Boolean(asset?.metadata?.id_only);
 }
@@ -271,7 +243,7 @@ export function buildSlotFunctionalCardViewModel(
     slot_type: slotType,
     media_type: slot?.media_type ?? "image",
     title: titleForSlot(slot, item),
-    prompt: slot?.slot_prompt ?? item?.item_prompt ?? "",
+    prompt: slot ? effectiveSlotPrompt(slot) : item?.item_prompt ?? "",
     prompt_source: slot?.prompt_source ?? item?.prompt_source ?? "system",
     manual_prompt_dirty: Boolean(slot?.manual_prompt_dirty),
     selected_asset: slot ? selectedAssetForSlot(workflow, slot) ?? null : null,
@@ -440,33 +412,6 @@ function collectReferenceIdsFromRelations(target: Set<string>, value: unknown) {
       if (typeof id === "string" && id.trim()) target.add(id.trim());
     }
   }
-}
-
-function outdatedSourcesFromMetadata(metadata: Record<string, unknown> | undefined): OutdatedSourceV2[] {
-  const rawSources = metadata?.outdated_sources ?? metadata?.outdated_source ?? metadata?.stale_sources;
-  if (Array.isArray(rawSources)) {
-    return rawSources
-      .map(outdatedSourceFromValue)
-      .filter((source): source is OutdatedSourceV2 => Boolean(source));
-  }
-  const source = outdatedSourceFromValue(rawSources);
-  return source ? [source] : [];
-}
-
-function outdatedSourceFromValue(value: unknown): OutdatedSourceV2 | null {
-  const record = recordValue(value);
-  if (!record) return null;
-  return {
-    source_node_id: firstString(record.source_node_id),
-    source_item_id: firstString(record.source_item_id),
-    source_slot_id: firstString(record.source_slot_id),
-    source_asset_id: firstString(record.source_asset_id),
-    old_asset_id: firstString(record.old_asset_id),
-    new_asset_id: firstString(record.new_asset_id),
-    reason: firstString(record.reason),
-    created_at: firstString(record.created_at),
-    metadata: recordValue(record.metadata),
-  };
 }
 
 function firstPresent(...values: unknown[]) {

--- a/apps/web/src/workflow-v2/slotControls.ts
+++ b/apps/web/src/workflow-v2/slotControls.ts
@@ -23,7 +23,7 @@ export function buildSlotCandidateRegenerateRequest(
   sourceAction: V2SlotCandidateRegenerateRequest["source_action"] = "slot_micro_prompt_send",
 ): V2SlotCandidateRegenerateRequest {
   return {
-    slot_prompt: stripInlineBase64(draft.prompt || slot.slot_prompt || ""),
+    slot_prompt: stripInlineBase64(draft.prompt),
     negative_prompt: stripInlineBase64(draft.negative_prompt ?? slot.negative_prompt ?? ""),
     reference_asset_ids: uniqueStrings([...(draft.reference_asset_ids ?? []), ...(draft.uploaded_asset_ids ?? [])]),
     library_entity_ids: uniqueStrings(draft.library_entity_ids ?? []),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,6 +33,12 @@ export default defineConfig({
           ) {
             return "app-core";
           }
+          if (
+            id.includes("/src/features/workflow/v2/screenplay/V2Screenplay") ||
+            id.includes("/src/features/workflow/v2/screenplay/screenplayUiHelpers")
+          ) {
+            return "screenplay-editor";
+          }
           if (id.includes("/src/features/workflow/") || id.includes("/src/workflow-v2/")) {
             return "workflow";
           }


### PR DESCRIPTION
## Summary
- add structured V2 planning errors and the complete screenplay API contract
- add conflict-safe screenplay editing, version history/selection, and canonical linked-context SSE refresh
- add layered Slot prompts and race-safe reference reconciliation while removing user-visible Outdated state
- lazy-load and portal the responsive screenplay editor with keyboard focus containment

## Verification
- 132/132 current V2 regression tests
- `npm run build`
- `npm run lint`
- `npm run perf:bundle`
- desktop/mobile Playwright checks against real V2 screenplay endpoints

Local-only `.superpowers`, `.codex`, tests, docs, frontend, and build outputs are excluded from this PR.