### PR TITLE
Add node context deletion and hide test-only model defaults

### DIFF
--- a/apps/web/src/features/agent-canvas/AgentCanvasPage.chrome.test.ts
+++ b/apps/web/src/features/agent-canvas/AgentCanvasPage.chrome.test.ts
@@ -61,6 +61,19 @@ describe("AgentCanvasPage chrome", () => {
     expect(source).toContain("onRelocate={openCanvasContextMenu}");
   });
 
+  it("opens the shared context menu for a node and routes deletion through canonical recovery", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/features/agent-canvas/AgentCanvasPageSurface.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("onNodeContextMenu={(event, node) => {");
+    expect(source).toContain("openNodeContextMenu(event, node)");
+    expect(source).toContain("const deleteContextNode = useCallback");
+    expect(source).toContain("deleteNodes([node])");
+    expect(source).toContain("onDeleteNode={() => deleteContextNode(contextMenu.nodeId)}");
+  });
+
   it("fills the Workflow viewport below the topbar without a shell inset", () => {
     const baseCss = readFileSync(resolve(process.cwd(), "src/styles/base.css"), "utf8");
     const canvasCss = readFileSync(

--- a/apps/web/src/features/agent-canvas/AgentCanvasPageSurface.tsx
+++ b/apps/web/src/features/agent-canvas/AgentCanvasPageSurface.tsx
@@ -10,7 +10,18 @@ import {
   useEdgesState,
   useNodesState,
 } from "@xyflow/react";
-import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 
 import { agentCanvasApi } from "../../api/agentCanvasApi.ts";
 import { createOperationKey } from "../../api/operationKey.ts";
@@ -184,10 +195,18 @@ export function AgentCanvasPage() {
     asset: ProjectAssetSummaryV2;
     title: string;
   } | null>(null);
-  const [contextMenu, setContextMenu] = useState<{
-    menuPosition: CanvasPositionV2;
-    canvasPosition: CanvasPositionV2;
-  } | null>(null);
+  const [contextMenu, setContextMenu] = useState<(
+    | {
+      kind: "canvas";
+      menuPosition: CanvasPositionV2;
+      canvasPosition: CanvasPositionV2;
+    }
+    | {
+      kind: "node";
+      menuPosition: CanvasPositionV2;
+      nodeId: string;
+    }
+  ) | null>(null);
   const [surfaceError, setSurfaceError] = useState<string | null>(null);
   const [connectionPolicy, setConnectionPolicy] = useState<CanvasConnectionPolicyV2 | null>(null);
   const [connectedNodeMenu, setConnectedNodeMenu] = useState<{
@@ -719,6 +738,29 @@ export function AgentCanvasPage() {
       .catch((error) => setSurfaceError(error instanceof Error ? error.message : "The node could not be deleted."));
   }, [deleteNode, recoverDeletedCanvasState]);
 
+  const deleteContextNode = useCallback((nodeId: string) => {
+    const node = flowNodesRef.current.find((candidate) => candidate.id === nodeId);
+    setContextMenu(null);
+    if (node) deleteNodes([node]);
+  }, [deleteNodes]);
+
+  const openNodeContextMenu = useCallback((
+    event: ReactMouseEvent,
+    node: AgentCanvasFlowNode,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    clearEdgeSelection();
+    setSelectedNodeId(node.id);
+    setAddMenuOpen(false);
+    setConnectedNodeMenu(null);
+    setContextMenu({
+      kind: "node",
+      menuPosition: { x: event.clientX, y: event.clientY },
+      nodeId: node.id,
+    });
+  }, [clearEdgeSelection, setSelectedNodeId]);
+
   const cancelCurrentRun = useCallback(async () => {
     setSurfaceError(null);
     try {
@@ -972,7 +1014,7 @@ export function AgentCanvasPage() {
     setSelectedNodeId(null);
     setAddMenuOpen(false);
     setConnectedNodeMenu(null);
-    setContextMenu({ menuPosition, canvasPosition });
+    setContextMenu({ kind: "canvas", menuPosition, canvasPosition });
   }, [clearEdgeSelection, setSelectedNodeId]);
 
   if (!session.state.workspaceHydrated) {
@@ -1046,6 +1088,9 @@ export function AgentCanvasPage() {
             clearEdgeSelection();
             setSelectedNodeId(node.id);
             focusCanvasNode(node.id);
+          }}
+          onNodeContextMenu={(event, node) => {
+            openNodeContextMenu(event, node);
           }}
           onNodeDragStart={(_event, node, draggedNodes) => {
             interruptReveal();
@@ -1278,13 +1323,22 @@ export function AgentCanvasPage() {
         />
 
         {contextMenu ? (
-          <AgentCanvasContextMenu
-            menuPosition={contextMenu.menuPosition}
-            canvasPosition={contextMenu.canvasPosition}
-            onCreateNode={(nodeType, position) => void createNode(nodeType, position)}
-            onClose={() => setContextMenu(null)}
-            onRelocate={openCanvasContextMenu}
-          />
+          contextMenu.kind === "node" ? (
+            <AgentCanvasContextMenu
+              menuPosition={contextMenu.menuPosition}
+              onDeleteNode={() => deleteContextNode(contextMenu.nodeId)}
+              onClose={() => setContextMenu(null)}
+              onRelocate={openCanvasContextMenu}
+            />
+          ) : (
+            <AgentCanvasContextMenu
+              menuPosition={contextMenu.menuPosition}
+              canvasPosition={contextMenu.canvasPosition}
+              onCreateNode={(nodeType, position) => void createNode(nodeType, position)}
+              onClose={() => setContextMenu(null)}
+              onRelocate={openCanvasContextMenu}
+            />
+          )
         ) : null}
 
         {connectedNodeMenu && connectedMenuAnchor && connectionPolicy ? (

--- a/apps/web/src/features/agent-canvas/canvas/AgentCanvasContextMenu.test.tsx
+++ b/apps/web/src/features/agent-canvas/canvas/AgentCanvasContextMenu.test.tsx
@@ -6,6 +6,25 @@ import { AgentCanvasContextMenu } from "./AgentCanvasContextMenu.tsx";
 afterEach(() => cleanup());
 
 describe("AgentCanvasContextMenu", () => {
+  it("shows one shared-style Delete node action for a node context menu", () => {
+    const onDeleteNode = vi.fn();
+
+    render(
+      <AgentCanvasContextMenu
+        menuPosition={{ x: 240, y: 180 }}
+        onDeleteNode={onDeleteNode}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const deleteAction = screen.getByRole("menuitem", { name: "Delete node" });
+    expect(deleteAction.className).toBe("agent-canvas-context-menu__action");
+    expect(screen.queryByRole("menuitem", { name: "Add node" })).toBeNull();
+
+    fireEvent.click(deleteAction);
+    expect(onDeleteNode).toHaveBeenCalledOnce();
+  });
+
   it("opens the shared node picker from Add node and creates at the context position", () => {
     const onCreateNode = vi.fn();
 

--- a/apps/web/src/features/agent-canvas/canvas/AgentCanvasContextMenu.tsx
+++ b/apps/web/src/features/agent-canvas/canvas/AgentCanvasContextMenu.tsx
@@ -1,17 +1,28 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { PlusIcon } from "../../../icons.tsx";
+import { PlusIcon, TrashIcon } from "../../../icons.tsx";
 import type { CanvasPositionV2 } from "../../../types-v2.ts";
 import type { AgentCanvasVisibleNodeTypeV2 } from "../model/nodeDefaults.ts";
 import { AgentCanvasNodePicker } from "./AgentCanvasNodePicker.tsx";
 
-interface AgentCanvasContextMenuProps {
+interface AgentCanvasContextMenuBaseProps {
   menuPosition: CanvasPositionV2;
-  canvasPosition: CanvasPositionV2;
-  onCreateNode: (nodeType: AgentCanvasVisibleNodeTypeV2, position: CanvasPositionV2) => void;
   onClose: () => void;
   onRelocate?: (menuPosition: CanvasPositionV2) => void;
 }
+
+type AgentCanvasContextMenuProps = AgentCanvasContextMenuBaseProps & (
+  | {
+    canvasPosition: CanvasPositionV2;
+    onCreateNode: (nodeType: AgentCanvasVisibleNodeTypeV2, position: CanvasPositionV2) => void;
+    onDeleteNode?: never;
+  }
+  | {
+    canvasPosition?: never;
+    onCreateNode?: never;
+    onDeleteNode: () => void;
+  }
+);
 
 const MENU_WIDTH = 212;
 const ACTION_MENU_HEIGHT = 58;
@@ -29,6 +40,7 @@ export function AgentCanvasContextMenu({
   menuPosition,
   canvasPosition,
   onCreateNode,
+  onDeleteNode,
   onClose,
   onRelocate,
 }: AgentCanvasContextMenuProps) {
@@ -67,7 +79,18 @@ export function AgentCanvasContextMenu({
         style={{ left: boundedPosition.x, top: boundedPosition.y }}
         onContextMenu={(event) => event.preventDefault()}
       >
-        {pickerOpen ? (
+        {onDeleteNode ? (
+          <button
+            type="button"
+            className="agent-canvas-context-menu__action"
+            role="menuitem"
+            autoFocus
+            onClick={onDeleteNode}
+          >
+            <TrashIcon />
+            <span>Delete node</span>
+          </button>
+        ) : pickerOpen && canvasPosition && onCreateNode ? (
           <AgentCanvasNodePicker
             className="agent-canvas-node-picker agent-canvas-context-menu__node-picker"
             menuLabel="Add node types"

--- a/apps/web/src/pages/ApiSpacePage.test.tsx
+++ b/apps/web/src/pages/ApiSpacePage.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ProviderModelSummaryV1 } from "../api/providerRegistry.ts";
+import { ModelDefaultsPanel } from "./api-space/ModelDefaultsPanel.tsx";
 import { ApiSpacePage } from "./ApiSpacePage.tsx";
 
 const fixture = vi.hoisted(() => ({
@@ -37,6 +39,8 @@ const providers = [
 
 const glm = model("siliconflow:zai-org/GLM-5.2", "SiliconFlow", "GLM-5.2", "text");
 const arkText = model("volcengine_ark:doubao-seed-2-0-mini-260428", "Volcengine Ark", "Doubao Seed 2.0 Mini", "text");
+const arkImage = model("volcengine_ark:doubao-seedream-4-0", "Volcengine Ark", "Doubao Seedream 4.0", "image");
+const deterministicImage = model("fake:deterministic-image", "fake", "Deterministic fake", "image");
 const tianpuyueAudio = model("tianpuyue:TemPolor-i3", "Tianpuyue", "TemPolor i3", "audio");
 const tianpuyueLongAudio = model("tianpuyue:TemPolor-i3.5", "Tianpuyue", "TemPolor i3.5", "audio");
 
@@ -50,8 +54,9 @@ describe("ApiSpacePage provider registry", () => {
     });
     fixture.api.listProviderModels.mockImplementation((query: { provider?: string; purpose?: string }) => {
       if (query.provider === "siliconflow") return Promise.resolve({ items: [glm] });
-      if (query.provider === "volcengine_ark") return Promise.resolve({ items: [arkText] });
+      if (query.provider === "volcengine_ark") return Promise.resolve({ items: [arkText, arkImage] });
       if (query.purpose === "agent" || query.purpose === "text") return Promise.resolve({ items: [glm, arkText] });
+      if (query.purpose === "image") return Promise.resolve({ items: [arkImage, deterministicImage] });
       if (query.purpose === "audio" || query.provider === "tianpuyue") return Promise.resolve({ items: [tianpuyueAudio, tianpuyueLongAudio] });
       return Promise.resolve({ items: [] });
     });
@@ -170,6 +175,41 @@ describe("ApiSpacePage provider registry", () => {
     }));
   });
 
+  it("excludes fake provider models from production default selectors", async () => {
+    render(<ApiSpacePage />);
+
+    const imageSelect = await screen.findByLabelText("Image default model");
+    await waitFor(() => expect(within(imageSelect).getByText("Doubao Seedream 4.0 · volcengine_ark")).toBeTruthy());
+    expect(within(imageSelect).queryByText("Deterministic fake · fake")).toBeNull();
+  });
+
+  it("does not expose a persisted fake default as an unavailable option", async () => {
+    render(
+      <ModelDefaultsPanel
+        defaults={{
+          defaults: { image: deterministicImage.model_ref },
+          modes: {},
+          revisions: { image: 1 },
+        }}
+        modelsByPurpose={{
+          agent: [],
+          text: [],
+          image: [arkImage, deterministicImage],
+          video: [],
+          audio: [],
+        }}
+        loading={false}
+        pending={false}
+        notice={null}
+        onSave={vi.fn()}
+      />,
+    );
+
+    const imageSelect = screen.getByLabelText("Image default model");
+    expect((imageSelect as HTMLSelectElement).value).toBe("");
+    expect(within(imageSelect).queryByText(`${deterministicImage.model_ref} (unavailable)`)).toBeNull();
+  });
+
   it("shows the backend-provided Audio routing mode beside its preferred model", async () => {
     render(<ApiSpacePage />);
 
@@ -223,7 +263,12 @@ function provider(provider_id: string, display_name: string, capabilities: strin
   };
 }
 
-function model(model_ref: string, provider: string, display_name: string, capability: string) {
+function model(
+  model_ref: string,
+  provider: string,
+  display_name: string,
+  capability: ProviderModelSummaryV1["capability"],
+): ProviderModelSummaryV1 {
   return {
     model_ref,
     provider_id: provider.toLocaleLowerCase().replaceAll(" ", "_"),

--- a/apps/web/src/pages/api-space/ModelDefaultsPanel.tsx
+++ b/apps/web/src/pages/api-space/ModelDefaultsPanel.tsx
@@ -81,21 +81,26 @@ export function ModelDefaultsPanel({
       </p>
       <div className="api-space-default-grid">
         {MODEL_DEFAULT_PURPOSES.map((purpose) => {
-          const options = modelsByPurpose[purpose];
+          const allOptions = modelsByPurpose[purpose];
+          const options = allOptions.filter((model) => model.provider_id !== "fake");
           const selected = modelDraft[purpose] ?? "";
-          const selectedMissing = Boolean(selected) && !options.some((model) => model.model_ref === selected);
+          const selectedIsTestOnly = selected.startsWith("fake:")
+            || allOptions.some((model) => model.model_ref === selected && model.provider_id === "fake");
+          const visibleSelected = selectedIsTestOnly ? "" : selected;
+          const selectedMissing = Boolean(visibleSelected)
+            && !options.some((model) => model.model_ref === visibleSelected);
           return (
             <div className="api-space-default-field" key={purpose}>
               <label htmlFor={`default-model-${purpose}`}>{defaultLabel(purpose)}</label>
               <select
                 id={`default-model-${purpose}`}
                 aria-label={`${defaultLabel(purpose)} default model`}
-                value={selected}
+                value={visibleSelected}
                 disabled={disabled}
                 onChange={(event) => updateModel(purpose, event.currentTarget.value)}
               >
                 <option value="">No default selected</option>
-                {selectedMissing ? <option value={selected}>{selected} (unavailable)</option> : null}
+                {selectedMissing ? <option value={visibleSelected}>{visibleSelected} (unavailable)</option> : null}
                 {options.map((model) => (
                   <option key={model.model_ref} value={model.model_ref}>
                     {model.display_name} · {model.provider_id}


### PR DESCRIPTION
## Summary
- add a node right-click menu with a shared-style Delete node action
- route deletion through the existing canonical node delete and recovery flow
- hide fake Provider models from production default-model selectors

## Verification
- `npm run test -- AgentCanvasContextMenu.test.tsx AgentCanvasPage.chrome.test.ts deleteCanvasEntities.test.ts ApiSpacePage.test.tsx`
- `npm run typecheck`
- `npm run build`