### PR TITLE
fix(web): copy vendored generative-loaders package before npm ci

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -5,6 +5,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
+COPY vendor ./vendor
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
npm ci resolves generative-loaders from file:vendor/generative-loaders-0.1.2.tgz, but the vendor directory was never copied into the build stage, so Docker builds failed at dependency installation.