### PR TITLE
fix(deploy): stop shadowing UI-saved credentials with empty env vars

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -29,8 +29,6 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
-    env_file:
-      - ./apps/api/.env
     environment:
       HOME: /tmp
       MEDIA_DATA_DIR: /app/data


### PR DESCRIPTION
compose env_file injects apps/api/.env values at container creation. When the file's key fields are still empty, empty-string env vars are frozen into the container environment and, because load_dotenv runs with override=False, they permanently shadow credentials saved later via the API Space UI: the provider model catalog then reports provider_credentials_missing and the default-model picker only offers fake.

The application already loads PROJECT_DOTENV_PATH itself at import (override=False keeps compose environment: overrides intact), so env_file is redundant and harmful. Remove it: UI credential saves now apply immediately without force-recreating the api container.