### PR TITLE
Fix Assets dialog dismissal and Windows native startup timer

### DIFF
--- a/apps/web/src/features/agent-canvas/AgentCanvasPage.chrome.test.ts
+++ b/apps/web/src/features/agent-canvas/AgentCanvasPage.chrome.test.ts
@@ -4,6 +4,24 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("AgentCanvasPage chrome", () => {
+  it("keeps the asset close action inside the panel and supports standard dismiss gestures", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/features/agent-canvas/AgentCanvasPageSurface.tsx"),
+      "utf8",
+    );
+    const assetSource = readFileSync(
+      resolve(process.cwd(), "src/features/agent-canvas/assets/AgentAssetBrowser.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('window.addEventListener("keydown", handleKeyDown)');
+    expect(source).toContain('if (event.key !== "Escape") return;');
+    expect(source).toContain("if (event.target === event.currentTarget) closeAssets();");
+    expect(source).toContain("onClose={closeAssets}");
+    expect(source).not.toContain("agent-canvas-overlay__close");
+    expect(assetSource).toContain('className="agent-asset-browser__close"');
+  });
+
   it("hides the React Flow attribution panel", () => {
     const source = readFileSync(
       resolve(process.cwd(), "src/features/agent-canvas/AgentCanvasPageSurface.tsx"),

--- a/apps/web/src/features/agent-canvas/AgentCanvasPageSurface.tsx
+++ b/apps/web/src/features/agent-canvas/AgentCanvasPageSurface.tsx
@@ -28,7 +28,6 @@ import { useApp } from "../../AppContextValue.ts";
 import { createOperationKey } from "../../api/operationKey.ts";
 import {
   AssetsIcon,
-  CloseIcon,
   LayoutIcon,
   PauseIcon,
   PlayIcon,
@@ -277,6 +276,19 @@ export function AgentCanvasPage() {
   const activeDraggedNodeIdsRef = useRef(new Set<string>());
   const canvasInteractionReasonsRef = useRef(new Set<CanvasInteractionReason>());
   const dragCancellationPendingRef = useRef(false);
+
+  const closeAssets = useCallback(() => setAssetsOpen(false), []);
+
+  useEffect(() => {
+    if (!assetsOpen) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      closeAssets();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [assetsOpen, closeAssets]);
 
   if (edgeZoomControllerRef.current === null) {
     edgeZoomControllerRef.current = createCanvasEdgeZoomController({
@@ -1506,21 +1518,22 @@ export function AgentCanvasPage() {
         ) : null}
 
         {assetsOpen ? (
-          <div className="agent-canvas-overlay agent-canvas-overlay--assets" role="dialog" aria-modal="true" aria-label="Project assets">
-            <button
-              type="button"
-              className="agent-canvas-overlay__close"
-              aria-label="Close assets"
-              title="Close assets"
-              onClick={() => setAssetsOpen(false)}
-            >
-              <CloseIcon />
-            </button>
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- the dialog backdrop dismisses on direct pointer input; Escape and the header button provide keyboard dismissal.
+          <div
+            className="agent-canvas-overlay agent-canvas-overlay--assets"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Project assets"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) closeAssets();
+            }}
+          >
             <Suspense fallback={null}>
               <AgentAssetBrowser
                 workflowId={workflow.workflow_id}
                 onAddReferences={addReferences}
                 onCreateReadySourceNode={createReadySourceNode}
+                onClose={closeAssets}
                 onUploadComplete={refreshWorkflow}
               />
             </Suspense>

--- a/apps/web/src/features/agent-canvas/agent-canvas-page.css
+++ b/apps/web/src/features/agent-canvas/agent-canvas-page.css
@@ -921,28 +921,6 @@
   backdrop-filter: blur(22px);
 }
 
-.agent-canvas-overlay__close {
-  position: absolute;
-  z-index: 4;
-  top: 16px;
-  right: 16px;
-  display: grid;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  place-items: center;
-  color: #53566b;
-  background: rgb(255 255 255 / 72%);
-  border: 1px solid rgb(98 101 129 / 15%);
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.agent-canvas-overlay__close svg {
-  width: 16px;
-  height: 16px;
-}
-
 .agent-canvas-overlay .agent-asset-browser {
   height: 100%;
 }
@@ -964,23 +942,6 @@
   width: min(960px, 100%);
   max-height: min(760px, 100%);
   min-height: 0;
-}
-
-.agent-canvas-overlay--assets .agent-canvas-overlay__close {
-  top: 10px;
-  right: 12px;
-  color: #f5f5f5;
-  background: #292929;
-  border: 1px solid #505050;
-}
-
-.agent-canvas-overlay--assets .agent-canvas-overlay__close:hover {
-  border-color: #a3a3a3;
-}
-
-.agent-canvas-overlay--assets .agent-canvas-overlay__close:focus-visible {
-  outline: 2px solid #f5f5f5;
-  outline-offset: 2px;
 }
 
 .agent-canvas-reference-upload-input {

--- a/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.css
+++ b/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.css
@@ -43,6 +43,13 @@
   padding-block: 16px 12px;
 }
 
+.agent-asset-browser__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .agent-asset-browser__title {
   display: flex;
   align-items: center;
@@ -99,6 +106,35 @@
 .agent-asset-browser__upload:hover:not(.is-busy) {
   background: #303030;
   border-color: #a3a3a3;
+}
+
+.agent-asset-browser__close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #f5f5f5;
+  cursor: pointer;
+  background: #292929;
+  border: 1px solid #505050;
+  border-radius: 6px;
+}
+
+.agent-asset-browser__close:hover {
+  background: #303030;
+  border-color: #a3a3a3;
+}
+
+.agent-asset-browser__close svg {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-asset-browser__close:focus-visible {
+  outline: 2px solid #f5f5f5;
+  outline-offset: 2px;
 }
 
 .agent-asset-browser__upload.is-busy {

--- a/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.test.tsx
+++ b/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.test.tsx
@@ -94,6 +94,21 @@ describe("AgentAssetBrowser", () => {
 
   afterEach(() => cleanup());
 
+  it("renders the close action in the asset header", () => {
+    const onClose = vi.fn();
+    render(
+      <AgentAssetBrowser
+        workflowId="workflow-1"
+        onAddReferences={vi.fn()}
+        onCreateReadySourceNode={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close assets" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it("copies selected files before resetting the native upload input", async () => {
     fixture.uploadAgentCanvasAsset.mockResolvedValue({ workflow_id: "workflow-1", asset: projectAsset("uploaded", "image") });
     render(<AgentAssetBrowser workflowId="workflow-1" onAddReferences={vi.fn()} onCreateReadySourceNode={vi.fn()} />);

--- a/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.tsx
+++ b/apps/web/src/features/agent-canvas/assets/AgentAssetBrowser.tsx
@@ -7,6 +7,7 @@ import {
 
 import {
   AssetsIcon,
+  CloseIcon,
   ImageIcon,
   MuteIcon,
   PlusIcon,
@@ -44,6 +45,7 @@ export interface AgentAssetBrowserProps {
   onCreateReadySourceNode: (
     selection: AgentAssetSourceNodeSelection,
   ) => Promise<void> | void;
+  onClose?: () => void;
   onUploadComplete?: () => Promise<void> | void;
 }
 
@@ -111,6 +113,7 @@ export function AgentAssetBrowser({
   uploadMetadata,
   onAddReferences,
   onCreateReadySourceNode,
+  onClose,
   onUploadComplete,
 }: AgentAssetBrowserProps) {
   const [scope, setScope] = useState<AgentAssetScope>("project");
@@ -229,21 +232,34 @@ export function AgentAssetBrowser({
             <p>Attach references or place ready media on the canvas.</p>
           </div>
         </div>
-        {scope === "project" ? (
-          <label className={`agent-asset-browser__upload${uploading ? " is-busy" : ""}`}>
-            <UploadIcon aria-hidden="true" />
-            <span>{uploading ? "Uploading" : "Upload"}</span>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*,video/*,audio/*"
-              multiple
-              aria-label="Upload project media"
-              disabled={uploading}
-              onChange={handleUpload}
-            />
-          </label>
-        ) : null}
+        <div className="agent-asset-browser__header-actions">
+          {scope === "project" ? (
+            <label className={`agent-asset-browser__upload${uploading ? " is-busy" : ""}`}>
+              <UploadIcon aria-hidden="true" />
+              <span>{uploading ? "Uploading" : "Upload"}</span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*,video/*,audio/*"
+                multiple
+                aria-label="Upload project media"
+                disabled={uploading}
+                onChange={handleUpload}
+              />
+            </label>
+          ) : null}
+          {onClose ? (
+            <button
+              type="button"
+              className="agent-asset-browser__close"
+              aria-label="Close assets"
+              title="Close assets"
+              onClick={onClose}
+            >
+              <CloseIcon />
+            </button>
+          ) : null}
+        </div>
       </header>
 
       <div className="agent-asset-browser__controls">

--- a/scripts/native-windows-common.ps1
+++ b/scripts/native-windows-common.ps1
@@ -296,7 +296,7 @@ function Wait-AdCraftNativeUrl([string]$Label, [string]$Url, [hashtable]$Headers
             Write-Host "`r[AdCraft] [$Label] 服务已就绪。                    "
             return
         }
-        $elapsed = [math]::Floor($stopwatch.Elapsed.TotalSeconds)
+        $elapsed = [int][math]::Floor($stopwatch.Elapsed.TotalSeconds)
         Write-Host -NoNewline ("`r[AdCraft] [{0}] 等待服务启动 {1} {2:D4}s/{3}s" -f $Label, $frames[$frameIndex], $elapsed, $timeoutSeconds)
         $frameIndex = ($frameIndex + 1) % $frames.Count
         Start-Sleep -Seconds 1


### PR DESCRIPTION
## Summary

- move the Assets dialog close action into the dialog header
- support dismissal with Escape and direct backdrop clicks
- cover the close action and dismissal wiring with focused tests
- cast the Windows native launcher elapsed time to an integer before applying the `D4` format specifier

## Verification

- `AgentAssetBrowser.test.tsx`: 8 tests passed
- focused `AgentCanvasPage.chrome.test.ts` dismissal test passed
- ESLint passed for all changed frontend files
- verified in the running app that the header button, Escape, and backdrop click all close the dialog
- native Windows launcher completed all eight stages and reported Agent, API, and Web healthy

## Existing upstream checks

- the full frontend typecheck still reports the pre-existing nullable `apiConfig` errors in `src/components/Layout.tsx`
- the full chrome test file still contains a pre-existing stale assertion expecting `dragEdgeProjection.frozenSnapshots` instead of `visibleFrozenSnapshots`