### PR TITLE
Fix Doubao Seedance 2.0 Mini model id: 250128 -> 260615

### DIFF
--- a/apps/api/app/services/provider_model_catalog.py
+++ b/apps/api/app/services/provider_model_catalog.py
@@ -599,20 +599,20 @@ _TRUSTED_MANIFESTS = (
     ),
     TrustedModelManifest(
         provider_id="volcengine_ark",
+        provider_model_id="doubao-seedance-2-0-mini-260615",
+        display_name="Doubao Seedance 2.0 Mini",
+        capability="video",
+        capability_metadata=_video_capability_metadata(
+            _ark_video_profile("volcengine_ark:doubao-seedance-2-0-mini-260615")
+        ),
+    ),
+    TrustedModelManifest(
+        provider_id="volcengine_ark",
         provider_model_id="doubao-seedance-2-0-260128",
         display_name="Doubao Seedance 2.0",
         capability="video",
         capability_metadata=_video_capability_metadata(
             _ark_video_profile("volcengine_ark:doubao-seedance-2-0-260128")
-        ),
-    ),
-    TrustedModelManifest(
-        provider_id="volcengine_ark",
-        provider_model_id="doubao-seedance-2-0-mini-260128",
-        display_name="Doubao Seedance 2.0 Mini",
-        capability="video",
-        capability_metadata=_video_capability_metadata(
-            _ark_video_profile("volcengine_ark:doubao-seedance-2-0-mini-260128")
         ),
     ),
     TrustedModelManifest(


### PR DESCRIPTION
Same class of trusted-catalog version-id defect as the Seedream 5.0 and Seedance 2.5 fixes: doubao-seedance-2-0-mini-260128 does not exist on Volcengine Ark; the live model is doubao-seedance-2-0-mini-260615. Full catalog sweep against GET /api/v3/models with a valid Ark key confirmed all other entries are valid.